### PR TITLE
fix dashboard select all action will cause the page goes blank.

### DIFF
--- a/src/components/serverPaginatedTable/serverPaginatedTable.js
+++ b/src/components/serverPaginatedTable/serverPaginatedTable.js
@@ -150,6 +150,18 @@ class ServerPaginatedTableView extends React.Component {
       rowsPerPage,
       rowsPerPageOptions: [],
       sortOrder,
+      onRowSelectionChange: (
+        curr,
+        allRowsSelected,
+        rowsSelected,
+        displayData,
+      ) => this.props.options.onRowSelectionChange(
+        curr,
+        allRowsSelected,
+        rowsSelected,
+        displayData,
+        data,
+      ),
       // eslint-disable-next-line no-shadow
       customFooter: (count, page, rowsPerPage, changeRowsPerPage, changePage) => (
         <TableFooter>

--- a/src/pages/dashboardTab/components/tabController.js
+++ b/src/pages/dashboardTab/components/tabController.js
@@ -148,10 +148,12 @@ const tabController = (classes) => {
   function Type1OnRowsSelect(data, allRowsSelected) {
   // use reduce to combine all the files' id into single array
     return allRowsSelected.reduce((accumulator, currentValue) => {
-      const { files } = data[currentValue.dataIndex];
-      // check if file
-      if (files && files.length > 0) {
-        return accumulator.concat(files.map((f) => f.file_id));
+      if (data[currentValue.dataIndex]) {
+        const { files } = data[currentValue.dataIndex];
+        // check if file exists
+        if (files && files.length > 0) {
+          return accumulator.concat(files.map((f) => f.file_id));
+        }
       }
       return accumulator;
     }, []);

--- a/src/pages/dashboardTab/components/tabView.js
+++ b/src/pages/dashboardTab/components/tabView.js
@@ -170,11 +170,11 @@ const TabView = ({
   /*
     Presist user selection
   */
-  function onRowsSelect(curr, allRowsSelected, rowsSelected, displayData) {
+  function onRowsSelect(curr, allRowsSelected, rowsSelected, displayData, selectedData) {
     rowSelectionEvent(displayData.map((d) => d.data[0]), rowsSelected);
 
     setSelectedIDs([...new Set(
-      customOnRowsSelect(data, allRowsSelected),
+      customOnRowsSelect(selectedData, allRowsSelected),
     )]);
     if (allRowsSelected.length === 0) {
       updateActiveSaveButtonStyle(true, saveButton);
@@ -193,12 +193,7 @@ const TabView = ({
       rowsSelected,
     ),
     rowsSelected: rowSelection.selectedRowIndex,
-    onRowSelectionChange: (curr, allRowsSelected, rowsSelected, displayData) => onRowsSelect(
-      curr,
-      allRowsSelected,
-      rowsSelected,
-      displayData,
-    ),
+    onRowSelectionChange: onRowsSelect,
     isRowSelectable: (dataIndex) => (disableRowSelection
       ? disableRowSelection(data[dataIndex], fileIDs) : true),
   });


### PR DESCRIPTION
## Description
fix dashboard select all action will cause the page goes blank.

The issue is onRowSelectionChange does not get proper data for customOnRowsSelect.  
Before Fix, the data only contains top 10 records,  after changed the number of records to be shown on the page, expected this data variable has all the data shown , however this data (invariant) still has only top 10 records.   When user check the records out of top 10 will cause undefined exception . 


