### PR TITLE
Changing backdrop for filteroverview

### DIFF
--- a/src/components/SideBar/SideBarComponents/FacetFilters.js
+++ b/src/components/SideBar/SideBarComponents/FacetFilters.js
@@ -50,6 +50,10 @@ const FacetPanel = ({ classes }) => {
     state.dashboardTab
   && state.dashboardTab.setSideBarLoading
       ? state.dashboardTab.setSideBarLoading : false));
+  const tabDataLoading = useSelector((state) => (state.dashboardTab
+    && state.dashboardTab.isDashboardTableLoading
+    ? state.dashboardTab.isDashboardTableLoading
+    : false));
   // redux use actions
   const dispatch = useDispatch();
 
@@ -232,7 +236,7 @@ const FacetPanel = ({ classes }) => {
               </List>
             </ExpansionPanelDetails>
           </ExpansionPanel>
-          <Backdrop className={classes.backdrop} open={isSidebarLoading}>
+          <Backdrop className={classes.backdrop} open={isSidebarLoading || tabDataLoading}>
             <CircularProgress color="inherit" />
           </Backdrop>
         </>
@@ -266,7 +270,7 @@ const styles = () => ({
     },
   },
   backdrop: {
-    position: 'absolute',
+    // position: 'absolute',
     zIndex: 99999,
     background: 'rgba(0, 0, 0, 0.1)',
   },

--- a/src/pages/dashboardTab/components/modal.js
+++ b/src/pages/dashboardTab/components/modal.js
@@ -31,7 +31,7 @@ const useStyles = makeStyles({
   },
   button: {
     borderRadius: '10px',
-    width: '100px',
+    width: '120px',
     lineHeight: '37px',
     fontSize: '12px',
     textTransform: 'uppercase',
@@ -112,7 +112,7 @@ export default function SimpleDialogDemo() {
   return (
     <>
       <button type="button" onClick={handleClickOpen} className={classes.button}>
-        Select All
+        Add All Files
       </button>
       <SimpleDialog open={open} onClose={handleClose} />
     </>

--- a/src/pages/dashboardTab/components/tabController.js
+++ b/src/pages/dashboardTab/components/tabController.js
@@ -41,11 +41,6 @@ const tabController = (classes) => {
     // get stats data from store
   const dashboardStats = useSelector((state) => (state.dashboardTab
     && state.dashboardTab.stats ? state.dashboardTab.stats : {}));
-  // get weather tab is loading from store
-  const tabDataLoading = useSelector((state) => (state.dashboardTab
-    && state.dashboardTab.isDashboardTableLoading
-    ? state.dashboardTab.isDashboardTableLoading
-    : false));
 
   const filteredSubjectIds = useSelector((state) => (state.dashboardTab
       && state.dashboardTab.filteredSubjectIds ? state.dashboardTab.filteredSubjectIds : []));
@@ -265,7 +260,6 @@ const tabController = (classes) => {
         defaultSortDirection={container.defaultSortDirection || 'asc'}
         dataKey={container.dataKey}
         filteredSubjectIds={filteredSubjectIds}
-        tabDataLoading={tabDataLoading}
       />
     </TabContainer>
   ));

--- a/src/pages/dashboardTab/components/tabView.js
+++ b/src/pages/dashboardTab/components/tabView.js
@@ -1,7 +1,5 @@
 import React, { useRef, useEffect } from 'react';
 import {
-  Backdrop,
-  CircularProgress,
   Grid,
   IconButton,
   withStyles,
@@ -51,7 +49,6 @@ const TabView = ({
   paginationAPIFieldDesc,
   dataKey,
   filteredSubjectIds,
-  tabDataLoading,
   defaultSortCoulmn,
   defaultSortDirection,
 }) => {
@@ -249,9 +246,6 @@ const TabView = ({
             defaultSortDirection={defaultSortDirection}
           />
         </Grid>
-        <Backdrop className={classes.backdrop} open={tabDataLoading}>
-          <CircularProgress color="inherit" />
-        </Backdrop>
       </Grid>
       <Grid item xs={12} className={classes.saveButtonDivBottom}>
         <button
@@ -293,7 +287,6 @@ const TabView = ({
               </div>
             ) : ''}
           <Link
-            target="_blank"
             rel="noreferrer"
             to={(location) => ({ ...location, pathname: '/fileCentricCart' })}
             color="inherit"
@@ -410,11 +403,6 @@ const styles = () => ({
   helpIconButton: {
     verticalAlign: 'top',
     marginLeft: '-5px',
-  },
-  backdrop: {
-    position: 'absolute',
-    zIndex: 99999,
-    background: 'rgba(0, 0, 0, 0.1)',
   },
 });
 


### PR DESCRIPTION
## Description

Adding backdrop to the whole dashboard while filtering action taking place

Fixes # (issue)
Adding backdrop to the whole dashboard while filtering action taking place
Removed Go to cart to open in new tab
Changes text of the select all to add all files

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?