### PR TITLE
Make environmental variables take precedence over injectedEnv.js

### DIFF
--- a/src/utils/env.js
+++ b/src/utils/env.js
@@ -2,8 +2,8 @@ const processEnv = typeof process !== 'undefined' ? process.env : {};
 const injectedEnv = window && window.injectedEnv ? window.injectedEnv : {};
 
 const env = {
-  ...processEnv,
   ...injectedEnv,
+  ...processEnv,
 };
 
 export default env;


### PR DESCRIPTION
So bento-local and normal local environment will work properly.