### PR TITLE
Fix when user updates the main clear/reset icon, the individual reset icons in the filters get updated automatically.

### DIFF
--- a/src/bento/dashboardData.js
+++ b/src/bento/dashboardData.js
@@ -146,6 +146,11 @@ export const resetIcon = {
   alt: 'Reset icon',
   size: '12 px',
 };
+export const resetIconFilter = {
+  src: 'https://raw.githubusercontent.com/CBIIT/datacommons-assets/main/bento/images/icons/svgs/Clear-icon.svg',
+  alt: 'Reset icon',
+  size: '12 px',
+};
 
 // --------------- Dashboard Table configuration --------------
 export const dashboardTable = {

--- a/src/components/SideBar/SideBarComponents/FacetFilters.js
+++ b/src/components/SideBar/SideBarComponents/FacetFilters.js
@@ -25,11 +25,17 @@ import {
   resetGroupSelections,
 } from '../../../pages/dashboardTab/store/dashboardReducer';
 import {
-  facetSectionVariables, defaultFacetSectionVariables, sortLabels, showCheckboxCount, resetIcon,
+  facetSectionVariables,
+  defaultFacetSectionVariables,
+  sortLabels, showCheckboxCount,
+  resetIconFilter,
 } from '../../../bento/dashboardData';
 import CheckBoxView from './CheckBoxView';
 
 const size = '10px';
+if (resetIconFilter.src === '') {
+  resetIconFilter.src = 'https://raw.githubusercontent.com/CBIIT/datacommons-assets/main/bento/images/icons/svgs/Clear-icon.svg';
+}
 const CustomExpansionPanelSummary = withStyles({
   root: {
     marginBottom: -1,
@@ -303,10 +309,10 @@ const FacetPanel = ({ classes }) => {
                                 style={{ fontSize: 15 }}
                               >
                                 <img
-                                  src={resetIcon.src}
+                                  src={resetIconFilter.src}
                                   height={size}
                                   width={size}
-                                  alt={resetIcon.alt}
+                                  alt={resetIconFilter.alt}
                                 />
                               </Icon>
                             </span>

--- a/src/components/SideBar/SideBarView.js
+++ b/src/components/SideBar/SideBarView.js
@@ -8,6 +8,9 @@ import { facetSearchData, resetIcon } from '../../bento/dashboardData';
 import { clearAllFilters } from '../../pages/dashboardTab/store/dashboardReducer';
 
 const drawerWidth = 240;
+if (resetIcon.src === '') {
+  resetIcon.src = 'https://raw.githubusercontent.com/CBIIT/datacommons-assets/main/bento/images/icons/svgs/Clear-icon.svg';
+}
 
 const SideBarContent = ({ classes }) => {
   const activeFilters = useSelector((state) => (


### PR DESCRIPTION
## Description

When the user updates the main clear/reset icon, the individual clear/reset icons in the filters will not get updated automatically. I also make the src value "https://raw.githubusercontent.com/CBIIT/datacommons-assets/main/bento/images/icons/svgs/Clear-icon.svg" as our default Icon src. If the Icon src is "", then the webpage will automatically switch to use default Icon src.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?