### PR TITLE
fix the sort order issue and clear local storage

### DIFF
--- a/src/pages/fileCentricCart/cartView.js
+++ b/src/pages/fileCentricCart/cartView.js
@@ -75,7 +75,7 @@ const cartView = ({
   const fileIdIndex = table.columns.map((d) => d.dataField).findIndex((e) => e === 'file_id');
 
   if (localStorage.getItem('data')) {
-    if (localStorage.getItem('data') !== 'undefined' && localStorage.getItem('data').length > 0 && (localStorage.getItem('page') !== localPage || localStorage.getItem('rowsPerPage') !== localRowsPerPage)) {
+    if (localStorage.getItem('data') !== 'undefined' && localStorage.getItem('data').length > 0 && (localStorage.getItem('page') !== localPage || localStorage.getItem('rowsPerPage') !== localRowsPerPage || localStorage.getItem('sortColumn') !== defaultSortCoulmn || localStorage.getItem('sortDirection') !== defaultSortDirection)) {
       const dataLocal = JSON.parse(localStorage.getItem('data'));
       dataCartView = dataLocal;
       localPageCartView = localStorage.getItem('page');

--- a/src/pages/fileCentricCart/store/cart.js
+++ b/src/pages/fileCentricCart/store/cart.js
@@ -108,11 +108,8 @@ const reducers = {
     if (fileIdsAfterDeletion.length === 0) {
       sortColumnValue = '';
       sortDirectionValue = '';
-      localStorage.setItem('sortColumn', sortColumnValue);
-      localStorage.setItem('sortDirection', sortDirectionValue);
-      localStorage.setItem('page', '0');
-      localStorage.setItem('rowsPerPage', '10');
-      localStorage.setItem('data', '');
+      // clear all local storage if we remove all record
+      localStorage.clear();
       return {
         ...state,
         fileIds: fileIdsAfterDeletion,


### PR DESCRIPTION
Fix the issue when commenting in the comment section. The sort order will go back to the previous state. Set up code in the cart.js to clear all the local storage when removing all the records.

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

