### PR TITLE
(BENTO-1933 & BENTO-1932) Custodian to configure Access Pop-up

### DIFF
--- a/src/bento/adminData.js
+++ b/src/bento/adminData.js
@@ -29,6 +29,8 @@ export const nodeName = 'Arm(s)'; // Node Name configured in the Data Access Req
 export const nodeField = 'numberOfArms'; // Node field
 
 export const nodeLevelAccess = env.NODE_LEVEL_ACCESS; // Node-Level Access is configured as "Off"
+
+export const commentField = 'Required';
 // --------------- tab Pending Request --------------
 export const tabPendingRequest = {
 

--- a/src/bento/adminData.js
+++ b/src/bento/adminData.js
@@ -28,7 +28,15 @@ export const nodeName = 'Arm(s)'; // Node Name configured in the Data Access Req
 
 export const nodeField = 'numberOfArms'; // Node field
 
-export const commentField = 'Required'; // Comment Field configured as "Required" for Access Pop-up
+/* Approve DAR Comment Field configuration
+    - "Optional" By Default or "Required"
+*/
+export const approveCommentField = 'Optional';
+
+/* Reject DAR Comment Field configuration
+    - "Optional" By Default or "Required"
+*/
+export const rejectCommentField = 'Optional';
 
 export const nodeLevelAccess = NODE_LEVEL_ACCESS; // Node-Level Access is configured as "Off"
 

--- a/src/pages/admin/reviewPendingDAR/components/Dialog.js
+++ b/src/pages/admin/reviewPendingDAR/components/Dialog.js
@@ -12,7 +12,6 @@ import {
 } from '@material-ui/core';
 import CloseIcon from '@material-ui/icons/Close';
 import { isEmpty } from 'lodash';
-import { commentField } from '../../../../bento/adminData';
 
 const BootstrapDialog = styled(Dialog)(() => ({
   '& .MuiBackdrop-root': {
@@ -56,11 +55,11 @@ const BootstrapDialog = styled(Dialog)(() => ({
 
 function CustomizedDialogs(props) {
   const {
-    classes, handleOpen, handleClose, handleConfrim, accessObj, comment, handleCommentChange,
+    classes, handleOpen, handleClose, handleConfrim,
+    accessObj, comment, handleCommentChange, commentField,
   } = props;
-  const {
-    dialogTitle, placeholder,
-  } = accessObj;
+
+  const { dialogTitle, placeholder } = accessObj;
 
   return (
     <div>

--- a/src/pages/admin/reviewPendingDAR/components/Dialog.js
+++ b/src/pages/admin/reviewPendingDAR/components/Dialog.js
@@ -11,6 +11,8 @@ import {
   Typography,
 } from '@material-ui/core';
 import CloseIcon from '@material-ui/icons/Close';
+import { isEmpty } from 'lodash';
+import { commentField } from '../../../../bento/adminData';
 
 const BootstrapDialog = styled(Dialog)(() => ({
   '& .MuiBackdrop-root': {
@@ -32,7 +34,7 @@ const BootstrapDialog = styled(Dialog)(() => ({
   '& .MuiDialogContent-root': {
     flex: '1 1 auto',
     padding: '0px 40px',
-    marginBottom: '45px',
+    marginBottom: ({ requiredMB }) => requiredMB || '45px',
     overflowY: 'auto',
   },
   '& .MuiDialogContentText-root': {
@@ -66,6 +68,7 @@ function CustomizedDialogs(props) {
         onClose={handleClose}
         open={handleOpen}
         aria-labelledby="Review Data Access Request(s) dialog"
+        requiredMB={commentField === 'Required' ? '25px' : ''}
       >
         <DialogTitle id={dialogTitle} className={classes.dialogTitleContainer}>
           <div className={classes.dialogTitleBox}>
@@ -85,7 +88,9 @@ function CustomizedDialogs(props) {
         </DialogTitle>
         <DialogContent>
           <DialogContentText>
-            Enter a comment that will be sent to the user.
+            Enter a comment that will be sent to the user
+            { commentField === 'Required' ? <sup className={classes.requiredAsterisk}>*</sup> : null }
+            .
           </DialogContentText>
           <textarea
             onChange={handleCommentChange}
@@ -94,12 +99,25 @@ function CustomizedDialogs(props) {
             placeholder={placeholder}
             label="Comment"
           />
+          {commentField === 'Required'
+            ? (
+              <div className={classes.requiredLabel}>
+                <sup className={classes.requiredAsterisk}>*</sup>
+                Comment is required.
+              </div>
+            )
+            : null}
         </DialogContent>
         <DialogActions className={classes.dialogActions}>
           <Button variant="contained" onClick={handleClose} className={classes.cancelButton}>
             CANCEL
           </Button>
-          <Button variant="contained" onClick={handleConfrim} className={classes.confrimButton}>
+          <Button
+            variant="contained"
+            onClick={handleConfrim}
+            className={classes.confrimButton}
+            {...commentField === 'Required' && isEmpty(comment && comment.trim()) ? { disabled: true } : {}}
+          >
             CONFIRM
           </Button>
         </DialogActions>
@@ -110,6 +128,13 @@ function CustomizedDialogs(props) {
 const styles = () => ({
   dialogTitleContainer: {
     borderBottom: '1.25px solid #BDBFC2',
+  },
+  requiredLabel: {
+    fontFamily: 'Lato',
+    fontSize: '16px',
+    color: 'red',
+    marginTop: '10px',
+    textAlign: 'center',
   },
   dialogTitleBox: {
     display: 'flex',
@@ -142,6 +167,7 @@ const styles = () => ({
     fontSize: '16px',
     fontFamily: 'Lato',
     resize: 'none',
+    marginBottom: ({ requiredTextMT }) => requiredTextMT || '0px',
   },
   cancelButton: {
     color: '#FFFFFF',
@@ -153,6 +179,11 @@ const styles = () => ({
     border: '1px solid #626262',
     backgroundColor: '#437BBE',
     marginLeft: '13px !important',
+  },
+  requiredAsterisk: {
+    fontFamily: 'Nunito Sans',
+    fontSize: '16px',
+    color: 'red',
   },
 });
 

--- a/src/pages/admin/reviewPendingDAR/reviewRequestView.js
+++ b/src/pages/admin/reviewPendingDAR/reviewRequestView.js
@@ -6,7 +6,13 @@ import { cn, CustomDataTable } from 'bento-components';
 import { useMutation } from '@apollo/client';
 import Stats from '../../../components/Stats/AllStatsController';
 import CustomizedDialogs from './components/Dialog';
-import { REJECT_ACCESS, APPROVE_ACCESS, adminPortalIcon } from '../../../bento/adminData';
+import {
+  REJECT_ACCESS,
+  APPROVE_ACCESS,
+  rejectCommentField,
+  approveCommentField,
+  adminPortalIcon,
+} from '../../../bento/adminData';
 import getFormattedDate, { getOnlyRequestedArms, showAlert } from './utils/reviewDARUtilFun';
 
 const ReviewRequestView = ({ classes, data }) => {
@@ -252,6 +258,7 @@ const ReviewRequestView = ({ classes, data }) => {
         handleConfrim={handleApproveAccess}
         comment={comment}
         handleCommentChange={handleCommentChange}
+        commentField={approveCommentField}
         accessObj={{
           dialogTitle: 'Approve Access',
           placeholder: 'e.g. Access to this Arm has been approved.',
@@ -264,6 +271,7 @@ const ReviewRequestView = ({ classes, data }) => {
         handleConfrim={handleRejectAccess}
         comment={comment}
         handleCommentChange={handleCommentChange}
+        commentField={rejectCommentField}
         accessObj={{
           dialogTitle: 'Reject Access',
           placeholder: 'e.g. Arm is restricted to authorized personnel.',


### PR DESCRIPTION
## Description
In this PR,
- Comment field are "Optional" by default. Custodian user can now configure Approve and Reject Access Pop-up's comment Field to be "Required" or "Optional".

Related Ticket:

> BENTO-1932, BENTO-1933

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?