### PR TITLE
BENTO-2055 & BENTO-2035

### DIFF
--- a/src/pages/admin/userDetails/userDetailView.js
+++ b/src/pages/admin/userDetails/userDetailView.js
@@ -305,7 +305,7 @@ const styles = (theme) => ({
   },
   infoKey: {
     whiteSpace: 'nowrap',
-    fontFamily: 'Nunito Sans',
+    fontFamily: 'Nunito',
     fontStyle: 'italic',
     fontWeight: '400', // regular
     fontSize: '12px',
@@ -315,7 +315,7 @@ const styles = (theme) => ({
   },
   infoValue: {
     lineHeight: '35px',
-    fontFamily: 'Nunito Sans',
+    fontFamily: 'Nunito',
     fontStyle: 'italic',
     fontWeight: '300', // light
     fontSize: '17px',
@@ -328,7 +328,7 @@ const styles = (theme) => ({
   },
   selectRole: {
     width: '140px',
-    fontFamily: 'Nunito Sans',
+    fontFamily: 'Nunito',
     fontStyle: 'italic',
     fontWeight: '300', // light
     fontSize: '17px',
@@ -360,7 +360,7 @@ const styles = (theme) => ({
     },
   },
   menuItem: {
-    fontFamily: 'Nunito Sans',
+    fontFamily: 'Nunito',
     fontSize: '16px',
     color: '#4F5D69 !important',
     height: '29px',
@@ -435,7 +435,7 @@ const styles = (theme) => ({
   },
   adminMessage: {
     color: '#000000',
-    fontFamily: '“Nunito”',
+    fontFamily: 'Nunito',
     fontSize: '18px',
     letterSpacing: '0',
     lineHeight: '35px',

--- a/src/pages/admin/userDetails/userDetailView.js
+++ b/src/pages/admin/userDetails/userDetailView.js
@@ -7,8 +7,8 @@ import CircularProgress from '@material-ui/core/CircularProgress';
 import Checkbox from '@material-ui/core/Checkbox';
 import Select from '@material-ui/core/Select';
 import MenuItem from '@material-ui/core/MenuItem';
-import { CustomDataTable } from 'bento-components';
-import _ from 'lodash';
+import { cn, CustomDataTable } from 'bento-components';
+
 import Stats from '../../../components/Stats/AllStatsController';
 import { columnInfo, options } from '../../../bento/userDetailViewData';
 
@@ -65,6 +65,7 @@ const UserDetailView = ({ classes, data, accessType = VIEW }) => {
   const [userInfo, setUserInfo] = useState(data.getUser);
   const [userRole, setUserRole] = useState(userInfo.role);
   const [seletedArms, setSeletedArms] = useState([]);
+  const { getAuthenticatorName, capitalizeFirstLetter } = custodianUtils;
 
   // GraphQL Operations
   // eslint-disable-next-line no-unused-vars
@@ -157,7 +158,12 @@ const UserDetailView = ({ classes, data, accessType = VIEW }) => {
               </Typography>
             </div>
           </div>
-          <div className={classes.userInfoHeader}>
+          <div className={
+            accessType === EDIT
+              ? cn(classes.editUserInfoHeader, classes.userInfoHeader)
+              : classes.userInfoHeader
+          }
+          >
             <div className={classes.firstInfoSection}>
               <div className={classes.infoKeyWrapper}>
                 <Typography className={classes.userInfo}>
@@ -169,16 +175,16 @@ const UserDetailView = ({ classes, data, accessType = VIEW }) => {
               <div>
                 <Typography className={classes.userInfo}>
                   <span className={classes.infoValue}>
-                    {custodianUtils.getAuthenticatorName(userInfo.IDP)}
+                    {getAuthenticatorName(userInfo.IDP)}
                   </span>
                   <span className={classes.infoValue}>
                     {userInfo.email}
                   </span>
                   <span className={classes.infoValue}>
-                    {_.startCase(userInfo.lastName)}
+                    {capitalizeFirstLetter(userInfo.lastName)}
                     ,
                     &nbsp;
-                    {_.startCase(userInfo.firstName)}
+                    {capitalizeFirstLetter(userInfo.firstName)}
                   </span>
                 </Typography>
               </div>
@@ -192,28 +198,32 @@ const UserDetailView = ({ classes, data, accessType = VIEW }) => {
                 </Typography>
               </div>
               <div>
-                <Typography className={classes.userInfo}>
+                <Typography component="div" className={classes.userInfo}>
                   <span className={classes.infoValue}>
-                    {_.startCase(userInfo.organization)}
+                    {capitalizeFirstLetter(userInfo.organization)}
                   </span>
                   <span className={classes.infoValue}>
-                    {_.startCase(userInfo.userStatus)}
+                    {capitalizeFirstLetter(userInfo.userStatus)}
                   </span>
-                  <span className={classes.infoValue}>
-                    {accessType === EDIT ? (
-                      <Select
-                        value={userRole}
-                        onChange={handleRoleChange}
-                        displayEmpty
-                        className={classes.selectEmpty}
-                        inputProps={{ 'aria-label': 'Without label' }}
-                      >
-                        <MenuItem value="admin"> Admin </MenuItem>
-                        <MenuItem value="member"> Member </MenuItem>
-                      </Select>
-                    )
-                      : _.startCase(userRole) }
-                  </span>
+                  {accessType === EDIT ? (
+                    <Select
+                      disableUnderline
+                      value={userRole}
+                      onChange={handleRoleChange}
+                      inputProps={{ 'aria-label': 'Without label' }}
+                      className={classes.selectRole}
+                      MenuProps={{
+                        anchorOrigin: { vertical: 'bottom', horizontal: 'left' },
+                        transformOrigin: { vertical: 'top', horizontal: 'left' },
+                        getContentAnchorEl: null,
+                        classes: { paper: classes.menuPaperStyle },
+                      }}
+                    >
+                      <MenuItem value="admin" className={classes.menuItem}> Admin </MenuItem>
+                      <MenuItem value="member" className={classes.menuItem}> Member </MenuItem>
+                    </Select>
+                  )
+                    : <span className={classes.infoValue}>{capitalizeFirstLetter(userRole)}</span> }
                 </Typography>
               </div>
             </div>
@@ -252,7 +262,6 @@ const UserDetailView = ({ classes, data, accessType = VIEW }) => {
     </>
   );
 };
-
 const styles = (theme) => ({
   adminTitle: {
     borderBottom: '1px solid #274FA5',
@@ -265,7 +274,7 @@ const styles = (theme) => ({
   },
   userInfoHeader: {
     minWidth: 'fit-content',
-    margin: '42px 0 38px 0',
+    margin: '42px 0 48px 0',
     padding: '0 0 0 36px',
     display: 'flex',
     gap: '12px',
@@ -273,6 +282,9 @@ const styles = (theme) => ({
     [theme.breakpoints.down('xs')]: {
       flexDirection: 'column',
     },
+  },
+  editUserInfoHeader: {
+    margin: '42px 0 78px 0',
   },
   firstInfoSection: {
     display: 'flex',
@@ -302,27 +314,57 @@ const styles = (theme) => ({
     lineHeight: '34px',
   },
   infoValue: {
+    lineHeight: '35px',
+    fontFamily: 'Nunito Sans',
+    fontStyle: 'italic',
+    fontWeight: '300', // light
+    fontSize: '17px',
+    color: '#4F5D69',
+    letterSpacing: 0,
     minHeight: '32px',
     whiteSpace: 'nowrap',
     marginLeft: '21px',
     float: 'left',
-    fontFamily: 'Nunito Sans',
-    fontStyle: 'italic',
-    fontWeight: '300', // light
-    fontSize: '17px',
-    color: '#4F5D69',
-    letterSpacing: 0,
-    lineHeight: '35px',
   },
-  selectEmpty: {
-    whiteSpace: 'nowrap',
+  selectRole: {
+    width: '140px',
     fontFamily: 'Nunito Sans',
     fontStyle: 'italic',
     fontWeight: '300', // light
     fontSize: '17px',
     color: '#4F5D69',
-    letterSpacing: 0,
-    lineHeight: '35px',
+    minHeight: '32px',
+    whiteSpace: 'nowrap',
+    marginLeft: '7px',
+    float: 'left',
+    '& .MuiSelect-select:focus': {
+      backgroundColor: 'white',
+    },
+    '& .MuiInput-input': {
+      paddingLeft: '15px !important',
+    },
+    '& .MuiSelect-icon': {
+      fontSize: '32px',
+      top: '0px',
+      color: '#5E6A76',
+    },
+  },
+  menuPaperStyle: {
+    width: '232px',
+    border: '1px solid #8493A0',
+    backgroundColor: '#F1F5FD',
+    borderRadius: '0px',
+    boxShadow: 'none',
+    '& .MuiList-padding': {
+      padding: '0px',
+    },
+  },
+  menuItem: {
+    fontFamily: 'Nunito Sans',
+    fontSize: '16px',
+    color: '#4F5D69 !important',
+    height: '29px',
+    paddingLeft: '14px',
   },
   upperCase: {
     textTransform: 'capitalize',

--- a/src/pages/admin/userDetails/userDetailView.js
+++ b/src/pages/admin/userDetails/userDetailView.js
@@ -314,7 +314,7 @@ const styles = (theme) => ({
     lineHeight: '34px',
   },
   infoValue: {
-    lineHeight: '35px',
+    lineHeight: '34px',
     fontFamily: 'Nunito',
     fontStyle: 'italic',
     fontWeight: '300', // light

--- a/src/pages/admin/userDetails/userDetailView.js
+++ b/src/pages/admin/userDetails/userDetailView.js
@@ -8,6 +8,7 @@ import Checkbox from '@material-ui/core/Checkbox';
 import Select from '@material-ui/core/Select';
 import MenuItem from '@material-ui/core/MenuItem';
 import { CustomDataTable } from 'bento-components';
+import _ from 'lodash';
 import Stats from '../../../components/Stats/AllStatsController';
 import { columnInfo, options } from '../../../bento/userDetailViewData';
 
@@ -20,6 +21,7 @@ import {
   EDIT,
 } from '../../../bento/adminData';
 import getDateInFormat from '../../../utils/date';
+import custodianUtils from '../../../utils/custodianUtilFuncs';
 
 // acl is array of object.
 function getApprovedArms(acl) {
@@ -158,38 +160,34 @@ const UserDetailView = ({ classes, data, accessType = VIEW }) => {
           <div className={classes.userInfoHeader}>
             <div className={classes.firstInfoSection}>
               <div className={classes.infoKeyWrapper}>
-                <Typography>
+                <Typography className={classes.userInfo}>
                   <span className={classes.infoKey}>ACCOUNT&nbsp;TYPE: </span>
                   {' '}
-                  <br />
                   <span className={classes.infoKey}>EMAIL&nbsp;ADDRESS: </span>
                   {' '}
-                  <br />
                   <span className={classes.infoKey}>NAME: </span>
                 </Typography>
               </div>
-              <div className={classes.userInfoValue}>
-                <Typography>
+              <div>
+                <Typography className={classes.userInfo}>
                   <span className={classes.infoValue}>
                     {' '}
-                    {userInfo.IDP}
+                    {custodianUtils.getAuthenticatorName(userInfo.IDP)}
                     {' '}
                   </span>
                   {' '}
-                  <br />
                   <span className={classes.infoValue}>
                     {' '}
                     {userInfo.email}
                     {' '}
                   </span>
                   {' '}
-                  <br />
                   <span className={classes.infoValue}>
                     {' '}
-                    {userInfo.lastName}
+                    {_.startCase(userInfo.lastName)}
                     ,
                     {' '}
-                    {userInfo.firstName}
+                    {_.startCase(userInfo.firstName)}
                   </span>
                 </Typography>
               </div>
@@ -199,29 +197,25 @@ const UserDetailView = ({ classes, data, accessType = VIEW }) => {
                 <Typography className={classes.userInfo}>
                   <span className={classes.infoKey}>ORGANIZATION: </span>
                   {' '}
-                  <br />
                   <span className={classes.infoKey}>MEMBERSHIP&nbsp;STATUS: </span>
                   {' '}
-                  <br />
                   <span className={classes.infoKey}>ROLE: </span>
                 </Typography>
               </div>
-              <div className={classes.userInfoValue}>
+              <div>
                 <Typography className={classes.userInfo}>
                   <span className={classes.infoValue}>
                     {' '}
-                    {userInfo.organization}
+                    {_.startCase(userInfo.organization)}
                     {' '}
                   </span>
                   {' '}
-                  <br />
                   <span className={classes.infoValue}>
                     {' '}
-                    {userInfo.userStatus}
+                    {_.startCase(userInfo.userStatus)}
                     {' '}
                   </span>
                   {' '}
-                  <br />
                   <span className={classes.infoValue}>
                     {' '}
                     {accessType === EDIT ? (
@@ -236,7 +230,7 @@ const UserDetailView = ({ classes, data, accessType = VIEW }) => {
                         <MenuItem value="member"> Member </MenuItem>
                       </Select>
                     )
-                      : userRole }
+                      : _.startCase(userRole) }
                     {' '}
                   </span>
                 </Typography>
@@ -312,18 +306,42 @@ const styles = (theme) => ({
       width: '120px',
     },
   },
+  userInfo: {
+    display: 'flex',
+    flexDirection: 'column',
+  },
   infoKey: {
     whiteSpace: 'nowrap',
+    fontFamily: 'Nunito Sans',
+    fontStyle: 'italic',
+    fontWeight: '400', // regular
+    fontSize: '12px',
     color: '#708292',
-    fontFamily: 'Nunito',
-    fontSize: '11px',
+    letterSpacing: 0,
+    lineHeight: '34px',
   },
   infoValue: {
+    minHeight: '32px',
     whiteSpace: 'nowrap',
     marginLeft: '21px',
     float: 'left',
+    fontFamily: 'Nunito Sans',
+    fontStyle: 'italic',
+    fontWeight: '300', // light
+    fontSize: '17px',
     color: '#4F5D69',
-    fontFamily: 'Nunito',
+    letterSpacing: 0,
+    lineHeight: '35px',
+  },
+  selectEmpty: {
+    whiteSpace: 'nowrap',
+    fontFamily: 'Nunito Sans',
+    fontStyle: 'italic',
+    fontWeight: '300', // light
+    fontSize: '17px',
+    color: '#4F5D69',
+    letterSpacing: 0,
+    lineHeight: '35px',
   },
   upperCase: {
     textTransform: 'capitalize',

--- a/src/pages/admin/userDetails/userDetailView.js
+++ b/src/pages/admin/userDetails/userDetailView.js
@@ -162,31 +162,22 @@ const UserDetailView = ({ classes, data, accessType = VIEW }) => {
               <div className={classes.infoKeyWrapper}>
                 <Typography className={classes.userInfo}>
                   <span className={classes.infoKey}>ACCOUNT&nbsp;TYPE: </span>
-                  {' '}
                   <span className={classes.infoKey}>EMAIL&nbsp;ADDRESS: </span>
-                  {' '}
                   <span className={classes.infoKey}>NAME: </span>
                 </Typography>
               </div>
               <div>
                 <Typography className={classes.userInfo}>
                   <span className={classes.infoValue}>
-                    {' '}
                     {custodianUtils.getAuthenticatorName(userInfo.IDP)}
-                    {' '}
                   </span>
-                  {' '}
                   <span className={classes.infoValue}>
-                    {' '}
                     {userInfo.email}
-                    {' '}
                   </span>
-                  {' '}
                   <span className={classes.infoValue}>
-                    {' '}
                     {_.startCase(userInfo.lastName)}
                     ,
-                    {' '}
+                    &nbsp;
                     {_.startCase(userInfo.firstName)}
                   </span>
                 </Typography>
@@ -196,28 +187,19 @@ const UserDetailView = ({ classes, data, accessType = VIEW }) => {
               <div className={classes.infoKeyWrapper}>
                 <Typography className={classes.userInfo}>
                   <span className={classes.infoKey}>ORGANIZATION: </span>
-                  {' '}
                   <span className={classes.infoKey}>MEMBERSHIP&nbsp;STATUS: </span>
-                  {' '}
                   <span className={classes.infoKey}>ROLE: </span>
                 </Typography>
               </div>
               <div>
                 <Typography className={classes.userInfo}>
                   <span className={classes.infoValue}>
-                    {' '}
                     {_.startCase(userInfo.organization)}
-                    {' '}
                   </span>
-                  {' '}
                   <span className={classes.infoValue}>
-                    {' '}
                     {_.startCase(userInfo.userStatus)}
-                    {' '}
                   </span>
-                  {' '}
                   <span className={classes.infoValue}>
-                    {' '}
                     {accessType === EDIT ? (
                       <Select
                         value={userRole}
@@ -231,7 +213,6 @@ const UserDetailView = ({ classes, data, accessType = VIEW }) => {
                       </Select>
                     )
                       : _.startCase(userRole) }
-                    {' '}
                   </span>
                 </Typography>
               </div>

--- a/src/utils/custodianUtilFuncs.js
+++ b/src/utils/custodianUtilFuncs.js
@@ -23,6 +23,12 @@ const custodianUtils = {
 
     return idpValue;
   },
+  // Capitalize first letter of each word
+  capitalizeFirstLetter: (str) => {
+    const words = str.split(' ');
+    return words.map((word) => word.charAt(0).toUpperCase() + word.substring(1)).join(' ');
+  },
+
 };
 
 export default custodianUtils;


### PR DESCRIPTION
## Description

In this PR:
- UI Styles for Admin/edit and Admin/view pages has been updated to match UI mock-up.
- Replace `startCase` with `capitalizeFirstLetter` to avoid startCase from removing special symbols/characters. Ex. Non**-**member

Fixes # (issue)
BENTO-2055, BENTO-2035

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?