### PR TITLE
remove unnecessary alert message

### DIFF
--- a/src/pages/accessManagment/login/view.js
+++ b/src/pages/accessManagment/login/view.js
@@ -93,19 +93,7 @@ function loginView({ classes }) {
 
   useEffect(() => {
     showAlert('redirect');
-
-    // validate the config
-    for (let i = 0; i < Object.values(idps).length; i) {
-      i += 1;
-      const provider = Object.values(idps)[i];
-      if (provider) {
-        if (typeof (provider.icon) === 'undefined' || typeof (provider.key) === 'undefined' || typeof (provider.loginButtonText) === 'undefined') {
-          showAlert('error', 'Incomplete configuration settings for selected Identity Provides');
-          break;
-        }
-      }
-    }
-  }, [Object.values(idps).length, internalRedirectPath]);
+  }, [internalRedirectPath]);
 
   return (
     <div className={classes.Container}>


### PR DESCRIPTION
Remove unnecessary alert message
No need to add error message if the no.of account type and icons are not matched