### PR TITLE
Bento 2174

### DIFF
--- a/src/pages/profile/components/profileFooterComponent.js
+++ b/src/pages/profile/components/profileFooterComponent.js
@@ -16,10 +16,9 @@ const ProfileViewFooter = ({ classes, data }) => {
   /**
    * Determines whether a given role can access the DAR button
    * @param {string} userRole The user's role
-   * @param {string} roleStatus The user's status of their role
    * @returns boolean
    */
-  const canAccessButton = (userRole, roleStatus) => {
+  const canAccessButton = (userRole) => {
     const roles = [
       'member',
       'non-member',
@@ -27,11 +26,6 @@ const ProfileViewFooter = ({ classes, data }) => {
 
     // User must be one of the roles above
     if (!roles.includes(userRole)) {
-      return false;
-    }
-
-    // Inactive is not allowed, unless user is member
-    if (roleStatus === 'inactive' && userRole !== 'member') {
       return false;
     }
 
@@ -58,7 +52,7 @@ const ProfileViewFooter = ({ classes, data }) => {
     </Box>
   );
 
-  const renderRequestButton = () => (canAccessButton(role, userStatus) ? (
+  const renderRequestButton = () => (canAccessButton(role) ? (
     <Box textAlign="center" sx={{ width: '100%' }}>
       <Button className={classes.btnRequest}>
         <Link to="/request" className={classes.btnRequestLink}>Request Access</Link>

--- a/src/pages/profile/components/profileFooterComponent.js
+++ b/src/pages/profile/components/profileFooterComponent.js
@@ -12,7 +12,31 @@ import getDateInFormat from '../../../utils/date';
 
 const ProfileViewFooter = ({ classes, data }) => {
   const { role, userStatus } = data.getMyUser;
-  const canAccessButton = ['member', 'non-member'].indexOf(role) !== -1 && userStatus !== 'inactive';
+
+  /**
+   * Determines whether a given role can access the DAR button
+   * @param {string} userRole The user's role
+   * @param {string} roleStatus The user's status of their role
+   * @returns boolean
+   */
+  const canAccessButton = (userRole, roleStatus) => {
+    const roles = [
+      'member',
+      'non-member',
+    ];
+
+    // User must be one of the roles above
+    if (!roles.includes(userRole)) {
+      return false;
+    }
+
+    // Inactive is not allowed, unless user is member
+    if (roleStatus === 'inactive' && userRole !== 'member') {
+      return false;
+    }
+
+    return true;
+  };
 
   const renderAdmin = () => (
     <Box sx={{
@@ -34,7 +58,7 @@ const ProfileViewFooter = ({ classes, data }) => {
     </Box>
   );
 
-  const renderRequestButton = () => (canAccessButton ? (
+  const renderRequestButton = () => (canAccessButton(role, userStatus) ? (
     <Box textAlign="center" sx={{ width: '100%' }}>
       <Button className={classes.btnRequest}>
         <Link to="/request" className={classes.btnRequestLink}>Request Access</Link>


### PR DESCRIPTION
## Description

Fixes DAR button not showing up for inactive members.

Fixes # [BENTO-2174](https://tracker.nci.nih.gov/browse/BENTO-2174)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I tested this by:

- logging in as an inactive member to confirm that it can see the DAR button
- logging in as a non-member to confirm that it can see the DAR button
- approving a non-member account to be a member, and logging in as the member to confirm that it can see the DAR button
- logging in as an admin to confirm that it cannot see the DAR button