### PR TITLE
Access control settings can now be specified in injectEnv.js

### DIFF
--- a/public/injectEnv.js
+++ b/public/injectEnv.js
@@ -20,4 +20,9 @@ window.injectedEnv = {
   // Client IDs for IDP
   REACT_APP_GOOGLE_CLIENT_ID: 'Sample id',
   REACT_APP_NIH_CLIENT_ID: 'Sample id',
+
+  // Access control settings
+  PUBLIC_ACCESS: 'Metadata Only',
+  NODE_LEVEL_ACCESS: true,
+  NODE_LABEL: 'Study Arm(s)',
 };

--- a/src/bento/siteWideConfig.js
+++ b/src/bento/siteWideConfig.js
@@ -1,3 +1,5 @@
+import env from '../utils/env';
+
 export default {
   // Suggested for replaceEmptyValueWith: 'N/A' or '-' or ''
   replaceEmptyValueWith: '',
@@ -13,11 +15,11 @@ export const adminPortal = '/admin';
 export const userProfileRoute = '/profile';
 
 // Public Level Access
-export const PUBLIC_ACCESS = 'Metadata Only';
+export const PUBLIC_ACCESS = env.PUBLIC_ACCESS || 'Metadata Only';
 
 // Node level access
-export const NODE_LEVEL_ACCESS = true;
-export const NODE_LABEL = 'Study Arm(s)';
+export const NODE_LEVEL_ACCESS = env.NODE_LEVEL_ACCESS || true;
+export const NODE_LABEL = env.NODE_LABEL || 'Study Arm(s)';
 
 // Redirect configs.
 export const REDIRECT_AFTER_SIGN_OUT = '/';


### PR DESCRIPTION
## Description

Access control settings can now be specified in injectEnv.js

Fixes # [BENTO-2207](https://tracker.nci.nih.gov/browse/BENTO-2207)

## How Has This Been Tested?

Changed values and confirmed effects in local environment for the following access control settings:

- PUBLIC_ACCESS
- NODE_LEVEL_ACCESS
- NODE_LABEL