### PR TITLE
Fix BENTO-2226/BENTO-2229 Theme Implementation

### DIFF
--- a/src/bento-core/Widgets/SunburstChart/SunburstChartGenerator.js
+++ b/src/bento-core/Widgets/SunburstChart/SunburstChartGenerator.js
@@ -4,6 +4,17 @@ import { makeStyles } from '@material-ui/core';
 import { Sunburst, LabelSeries } from 'react-vis';
 
 const DEFAULT_CLASSES = makeStyles({
+  label: {
+    fontSize: '12px',
+    textAnchor: 'middle',
+    textAlign: 'center',
+    fill: (props) => (props && props.textColor ? props.textColor : 'black'),
+    fontFamily: (props) => (props && props.fontFamily ? props.fontFamily : 'Nunito'),
+    '& text': {
+      fill: (props) => (props && props.textColor ? props.textColor : 'black'),
+      textAnchor: 'middle',
+    },
+  },
   widgetContainer: {
     marginTop: (props) => (props && props.titleLocation === 'top' ? '0px' : '18px'),
     marginBottom: (props) => (props.titleLocation === 'top' ? '18px' : '0px'),
@@ -23,12 +34,6 @@ export const DEFAULT_CONFIG_SUNBURST = {
   // Styles used by the component and its children
   styles: {
     textColor: 'black',
-    label: {
-      fontSize: '12px',
-      textAnchor: 'middle',
-      fill: 'black',
-      fontFamily: '"Nunito","Open Sans", sans-serif',
-    },
     sunburst: {
       stroke: '#ddd',
       strokeOpacity: 0.3,
@@ -192,24 +197,20 @@ export const SunburstChartGenerator = (uiConfig = DEFAULT_CONFIG_SUNBURST) => {
             {/* This cannot be it's own component */}
             {/* https://github.com/uber/react-vis/issues/1095 */}
             {state.caseSize > 0 && (
-              <LabelSeries data={[
-                {
-                  x: 0,
-                  y: 0,
-                  label: state.caseSize,
-                  style: styles && styles.label
-                    ? styles.label
-                    : DEFAULT_CONFIG_SUNBURST.styles.label,
-                },
-                {
-                  x: 0,
-                  y: 1,
-                  label: sliceTitle,
-                  style: styles && styles.label
-                    ? styles.label
-                    : DEFAULT_CONFIG_SUNBURST.styles.label,
-                },
-              ]}
+              <LabelSeries
+                className={classes.label}
+                data={[
+                  {
+                    x: 0,
+                    y: 0,
+                    label: state.caseSize,
+                  },
+                  {
+                    x: 0,
+                    y: 1,
+                    label: sliceTitle,
+                  },
+                ]}
               />
             )}
           </Sunburst>

--- a/src/pages/dashTemplate/widget/WidgetView.js
+++ b/src/pages/dashTemplate/widget/WidgetView.js
@@ -5,7 +5,6 @@ import {
   FormControlLabel,
   Grid,
   Switch,
-  Typography,
   withStyles,
 } from '@material-ui/core';
 import { useTheme } from '../../../components/ThemeContext';
@@ -14,6 +13,7 @@ import { WidgetGenerator } from '../../../bento-core/Widgets';
 import { widgetsData } from '../../../bento/dashboardData';
 import colors from '../../../utils/colors';
 import { getWidgetsInitData } from '../../dashboardTab/store/dashboardReducer';
+import { Typography } from '../../../components/Wrappers/Wrappers';
 
 const WidgetView = ({
   classes,
@@ -32,9 +32,14 @@ const WidgetView = ({
       styles: {
         cellPadding: 2,
         textOverflowLength: 20,
+        textColor: theme.palette.widgetBackground.contrastText,
       },
     },
-    SunburstConfig: {},
+    SunburstConfig: {
+      styles: {
+        textColor: theme.palette.widgetBackground.contrastText,
+      },
+    },
   };
   const { Widget } = WidgetGenerator(widgetGeneratorConfig);
 
@@ -80,14 +85,7 @@ const WidgetView = ({
               <Grid key={index} item lg={4} md={6} sm={12} xs={12}>
                 <Widget
                   header={(
-                    <Typography
-                      colorBrightness={theme.palette.lochmara.contrastText}
-                      size="md"
-                      weight="normal"
-                      family="Nunito"
-                      color={theme.palette.lochmara.contrastText}
-                      className={classes.widgetTitle}
-                    >
+                    <Typography size="md" weight="normal" family="Nunito" color="lochmara">
                       {widget.title}
                     </Typography>
                   )}

--- a/src/pages/dashboardTab/dashboard.js
+++ b/src/pages/dashboardTab/dashboard.js
@@ -26,9 +26,14 @@ const Dashboard = ({
       styles: {
         cellPadding: 2,
         textOverflowLength: 20,
+        textColor: theme.palette.widgetBackground.contrastText,
       },
     },
-    SunburstConfig: {},
+    SunburstConfig: {
+      styles: {
+        textColor: theme.palette.widgetBackground.contrastText,
+      },
+    },
   };
   const { Widget } = WidgetGenerator(widgetGeneratorConfig);
 
@@ -85,14 +90,7 @@ const Dashboard = ({
                         <Grid key={index} item lg={4} md={6} sm={12} xs={12}>
                           <Widget
                             header={(
-                              <Typography
-                                colorBrightness={theme.palette.lochmara.contrastText}
-                                size="md"
-                                weight="normal"
-                                family="Nunito"
-                                color={theme.palette.lochmara.contrastText}
-                                className={classes.widgetTitle}
-                              >
+                              <Typography size="md" weight="normal" family="Nunito" color="lochmara">
                                 {widget.title}
                               </Typography>
                             )}


### PR DESCRIPTION
## Description

This is a minor bug fix to BENTO-2229 (via BENTO-2226) that addresses missing theme usage on the explore page.

Fixes # (issue)

- BENTO-2229

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Go to the /explore page and enable/disable dark mode. Compare to 3.10 or QA.