### PR TITLE
BENTO-2356 Add table cell displayEmpty config option

### DIFF
--- a/packages/bento-frontend/src/bento-core/Table/body/CustomCell.js
+++ b/packages/bento-frontend/src/bento-core/Table/body/CustomCell.js
@@ -48,7 +48,12 @@ const ViewCell = ({
   row,
   rootClsName,
 }) => {
-  const { cellType } = column;
+  const {
+    cellType,
+    showEmpty = true,
+    dataField,
+  } = column;
+  const value = !row[dataField] && !showEmpty ? '' : row[dataField];
   switch (cellType) {
     case cellTypes.LINK:
       return (
@@ -58,7 +63,7 @@ const ViewCell = ({
           rootClsName={rootClsName}
         >
           <Typography className={`${rootClsName}_${cellTypes.LINK}_label`}>
-            {row[column.dataField]}
+            {value}
           </Typography>
         </CustomLink>
       );
@@ -72,7 +77,7 @@ const ViewCell = ({
     default:
       return (
         <Typography className={`${rootClsName}_${cellTypes.DEFAULT}`}>
-          {row[column.dataField]}
+          {value}
         </Typography>
       );
   }

--- a/packages/bento-frontend/src/bento/dashboardTabData.js
+++ b/packages/bento-frontend/src/bento/dashboardTabData.js
@@ -1330,6 +1330,7 @@ export const tabContainers = [
         sort: 'asc',
         display: true,
         tooltipText: 'sort',
+        showEmpty: false,
       },
     ],
     id: 'case_tab',


### PR DESCRIPTION
## Description

Adds a custodian option to `tabContainers` columns configuration to disable showing empty values (e.g. `0` or empty string) from the table cell view. This is a non-breaking change and defaults the `showHidden` option to true.

Previously:
<img width="213" alt="image" src="https://user-images.githubusercontent.com/38357871/230118415-c144f7f4-da5d-44f6-9fb6-42630d20cceb.png">

Now:
<img width="213" alt="image" src="https://user-images.githubusercontent.com/38357871/230118501-7ef8e56d-ccfc-40d5-8861-ca4fdea9038b.png">

Fixes # (issue)

- [BENTO-3456](https://tracker.nci.nih.gov/browse/BENTO-2356)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] This change requires a documentation update

## How Has This Been Tested?

Tested locally on 4.0 before/after update.