### PR TITLE
BENTO-2356 Add custom element for Survival Days cell

### DIFF
--- a/packages/bento-frontend/src/bento/dashboardTabData.js
+++ b/packages/bento-frontend/src/bento/dashboardTabData.js
@@ -1795,6 +1795,8 @@ export const tabContainers = [
         display: true,
         tooltipText: 'sort',
         role: cellTypes.DISPLAY,
+        cellType: cellTypes.CUSTOM_ELEM,
+        displayEmpty: false,
       },
     ],
     id: 'case_tab',

--- a/packages/bento-frontend/src/pages/dashTemplate/tabs/tableConfig/Column.js
+++ b/packages/bento-frontend/src/pages/dashTemplate/tabs/tableConfig/Column.js
@@ -1,9 +1,13 @@
 import React from 'react';
+import { Typography } from '@material-ui/core';
 import { cellTypes, headerTypes } from '../../../../bento-core/Table/util/Types';
 import DocumentDownloadView from '../../../../components/DocumentDownload/DocumentDownloadView';
 
 export const CustomCellView = (props) => {
-  const { downloadDocument, documentDownloadProps } = props;
+  const {
+    downloadDocument, documentDownloadProps,
+    displayEmpty, dataField,
+  } = props;
   if (downloadDocument) {
     return (
       <DocumentDownloadView
@@ -15,7 +19,10 @@ export const CustomCellView = (props) => {
         {...props}
       />
     );
+  } else if (typeof displayEmpty === "boolean") {
+    return (<Typography>{displayEmpty || props[dataField] ? props[dataField] : ""}</Typography>);
   }
+
   // other custom elem
   return (<></>);
 };


### PR DESCRIPTION
## Description

> **Warning**: This is based on branch `Monorepo_migration` for PR #756 

Adds a custodian configuration change and provides a custom component for cells where we want to filter `0`, `null`, or any [falsy](https://developer.mozilla.org/en-US/docs/Glossary/Falsy) values.

Previously:
<img width="213" alt="image" src="https://user-images.githubusercontent.com/38357871/230118415-c144f7f4-da5d-44f6-9fb6-42630d20cceb.png">

Now:
<img width="213" alt="image" src="https://user-images.githubusercontent.com/38357871/230118501-7ef8e56d-ccfc-40d5-8861-ca4fdea9038b.png">

Fixes # (issue)

- [BENTO-2356](https://tracker.nci.nih.gov/browse/BENTO-2356)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] This change requires a documentation update

## How Has This Been Tested?

Tested locally on 4.0 before/after update.