### PR TITLE
Automatically build all components when running "npx lerna run start"

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -18,6 +18,11 @@
       "outputs": [
         "{projectRoot}/dist"
       ]
+    },
+    "start": {
+      "dependsOn": [
+        "^build"
+      ]
     }
   }
 }


### PR DESCRIPTION
Currently, we have to run npx lerna run build before running npx lerna run start.