### PR TITLE
BENTO-2436 Reset active facets on redirect

### DIFF
--- a/packages/bento-frontend/src/pages/programDetail/programDetailView.js
+++ b/packages/bento-frontend/src/pages/programDetail/programDetailView.js
@@ -19,19 +19,13 @@ import {
 } from '../../bento/programDetailData';
 import StatsView from '../../components/Stats/StatsView';
 import { Typography } from '../../components/Wrappers/Wrappers';
-import {
-  setSideBarToLoading, setDashboardTableLoading,
-} from '../dashboardTab/store/dashboardReducer';
 import CustomBreadcrumb from '../../components/Breadcrumb/BreadcrumbView';
 import colors from '../../utils/colors';
 import { WidgetGenerator } from '@bento-core/widgets';
-import {toggleCheckBox} from '@bento-core/facet-filter';
-import { useDispatch } from 'react-redux';
 import { onClearAllAndSelectFacetValue } from '../dashTemplate/sideBar/BentoFilterUtils';
 
 const ProgramView = ({ classes, data, theme }) => {
   const programData = data.programDetail;
-  const dispatch = useDispatch();
 
   const widgetGeneratorConfig = {
     theme,
@@ -46,15 +40,7 @@ const ProgramView = ({ classes, data, theme }) => {
 
   const { Widget } = WidgetGenerator(widgetGeneratorConfig);
 
-  const redirectToArm = (programArm) => {
-    setSideBarToLoading();
-    setDashboardTableLoading();
-    dispatch(toggleCheckBox({
-      name: `${programArm.rowData[0]}: ${programArm.rowData[1]}`,
-      datafield: 'studies',
-      isChecked: true,
-    }));
-  };
+  const redirectToArm = (programArm) => onClearAllAndSelectFacetValue('studies', `${programArm.rowData[0]}: ${programArm.rowData[1]}`);
 
   const stat = {
     numberOfPrograms: 1,

--- a/packages/bento-frontend/src/pages/programs/programsView.js
+++ b/packages/bento-frontend/src/pages/programs/programsView.js
@@ -10,24 +10,10 @@ import {
 } from '../../bento/programData';
 import Stats from '../../components/Stats/AllStatsController';
 import { Typography } from '../../components/Wrappers/Wrappers';
-import {
-  setSideBarToLoading, setDashboardTableLoading,
-} from '../dashboardTab/store/dashboardReducer';
-import {toggleCheckBox} from '@bento-core/facet-filter';
-import { useDispatch } from 'react-redux';
+import { onClearAllAndSelectFacetValue } from '../dashTemplate/sideBar/BentoFilterUtils';
 
 const Programs = ({ classes, data }) => {
-  const dispatch = useDispatch();
-
-  const redirectTo = (program) => {
-    setSideBarToLoading();
-    setDashboardTableLoading();
-    dispatch(toggleCheckBox({
-      name: program.rowData[0],
-      datafield: 'programs',
-      isChecked: true,
-    }));
-  };
+  const redirectTo = (program) => onClearAllAndSelectFacetValue('programs', program.rowData[0]);
 
   return (
     <>


### PR DESCRIPTION
## Description

This PR resolves a bug in which multiple facets remain selected when being redirected from the program listing or program detail pages. It also removes unused events from being dispatched.

Fixes # [BENTO-2436](https://tracker.nci.nih.gov/browse/BENTO-2436)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Compared QA deployment vs local environment to ensure the bug did not persist. 