### PR TITLE
BENTO-2426 Fix Dashboard/Explore Right side gutter width

### DIFF
--- a/packages/bento-frontend/src/pages/dashTemplate/DashTemplateStyle.js
+++ b/packages/bento-frontend/src/pages/dashTemplate/DashTemplateStyle.js
@@ -18,7 +18,7 @@ export default () => ({
     zIndex: '99',
   },
   rightContent: {
-    maxWidth: 'calc(100% - 250px)',
+    width: 'calc(100% - 250px)',
     position: 'relative',
     borderRight: 'thin solid #B1B1B1',
   },


### PR DESCRIPTION
## Description

This PR addresses an issue with the dynamic width of the dashboard/explore page in which various components allow the dashboard width to shrink or grow inconsistently with the 3.10 dashboard design.

Fixes #: [BENTO-2426](https://tracker.nci.nih.gov/browse/BENTO-2426)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

In Bento `4.0.0`:

1. Select a combination of facets and local find cases so that there are no records matching
2. The widgets should be hidden and the tables should be empty
3. Switch to any of the table tabs (cases, samples, files) and observe
4. The gap on the rightmost edge of the dashboard page changes depending on the number of columns in the table

This gap should be consistent with the old dashboard design in Bento 3.10.0 or earlier