### PR TITLE
BENTO-2451 Partial fix for incorrect theme switch

### DIFF
--- a/packages/bento-frontend/src/pages/dashTemplate/widget/WidgetView.js
+++ b/packages/bento-frontend/src/pages/dashTemplate/widget/WidgetView.js
@@ -65,9 +65,8 @@ const WidgetView = ({
             }}
             className={classes.customSwitch}
             disableRipple
-            onChange={() => {
-              themeChanger.toggleTheme();
-            }}
+            checked={themeChanger.dark}
+            onChange={themeChanger.toggleTheme}
           />
         </div>
       </div>


### PR DESCRIPTION
## Description

This PR provides a temporary fix to the widget theme change switch not displaying as on/off correctly.

Fixes # [BENTO-2541](https://tracker.nci.nih.gov/browse/BENTO-2451)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Compared pre-fix to post-fix and verified that the switch correctly indicates the on/off status of the dark theme.