### PR TITLE
Case IDs in the middle of the modal can be changed

### DIFF
--- a/packages/local-find/src/UploadModal/UploadModalGenerator.js
+++ b/packages/local-find/src/UploadModal/UploadModalGenerator.js
@@ -50,6 +50,10 @@ export const UploadModalGenerator = (uiConfig = DEFAULT_CONFIG) => {
     ? config.projectName
     : DEFAULT_CONFIG.config.projectName;
 
+  const caseIds = config && config.caseIds && typeof config.caseIds === 'string'
+    ? config.caseIds
+    : DEFAULT_CONFIG.config.caseIds;
+
   const modalClosed = functions && typeof functions.modalClosed === 'function'
     ? functions.modalClosed
     : DEFAULT_CONFIG.functions.modalClosed;
@@ -251,6 +255,7 @@ export const UploadModalGenerator = (uiConfig = DEFAULT_CONFIG) => {
                 matchedLabel={matchedLabel}
                 associateLabel={associateLabel}
                 projectName={projectName}
+                caseIds={caseIds}
                 error={overMaxTerms ? errorText : null}
               />
             )}

--- a/packages/local-find/src/UploadModal/components/SummaryTable.js
+++ b/packages/local-find/src/UploadModal/components/SummaryTable.js
@@ -25,6 +25,7 @@ const SummaryTable = (props) => {
     matchedLabel,
     associateLabel,
     projectName,
+    caseIds,
   } = props;
 
   const [tab, setTab] = useState('matched');
@@ -32,7 +33,7 @@ const SummaryTable = (props) => {
   return (
     <div className={classes.summaryContainer} id="uploadCaseSetSummarySection">
       <p className={classes.summary} id="uploadCaseSetSummaryCount">
-        {`${matched.length + unmatched.length} submitted Case IDs mapped to ${matched.length} unique ${projectName} Case IDs`}
+        {`${matched.length + unmatched.length} submitted ${caseIds} mapped to ${matched.length} unique ${projectName} ${caseIds}`}
       </p>
       {error ? (
         <Typography className={clsx(classes.summary, classes.error)}>

--- a/packages/local-find/src/UploadModal/config.js
+++ b/packages/local-find/src/UploadModal/config.js
@@ -26,6 +26,7 @@ export const DEFAULT_CONFIG_UPLOADMODAL = {
     associateId: 'program_id',
     associateLabel: 'ASSOCIATED PROGRAM',
     projectName: 'BENTO',
+    caseIds: 'Case IDs',
   },
 
   // Helper functions used by the component


### PR DESCRIPTION
## Description

The Upload Modal was hard coded to expect Case IDs in the middle of the modal, this provides the flexibility to change it dependent on the project

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?