### PR TITLE
Added appendStringsToRecord function to Paginated table. Making it flexible enough that other projects can use it if needed.

### DIFF
--- a/packages/cart/src/utils.js
+++ b/packages/cart/src/utils.js
@@ -35,7 +35,7 @@ export function convertToCSV(jsonse, comments, keysToInclude, header) {
       if (commentResult.search(/("|,|\n)/g) >= 0) commentResult = `"${commentResult}"`;
       str += `\r\n${line},${commentResult}\r\n`;
     } else {
-      str += `${line}\r\n`;
+      str += `${line},\r\n`;
     }
     return str;
   });

--- a/packages/paginated-table/src/wrapper/components/DownloadManifestBtn.js
+++ b/packages/paginated-table/src/wrapper/components/DownloadManifestBtn.js
@@ -29,6 +29,15 @@ const DownloadManifestView = (props) => {
     return variables;
   };
 
+  const appendStringsToRecord = (records, columnsToAppendString) => records.map((record) => {
+    const updatedRecord = record;
+    columnsToAppendString.forEach((columnConfigObject) => {
+      updatedRecord[columnConfigObject.dataField] = columnConfigObject.appendString
+        + updatedRecord[columnConfigObject.dataField];
+    });
+    return updatedRecord;
+  });
+
   const client = useApolloClient();
   async function fetchData({ queryVariables, table }) {
     const fetchResult = await client
@@ -38,7 +47,16 @@ const DownloadManifestView = (props) => {
           ...getQueryVeriables(queryVariables),
         },
       })
-      .then((result) => result.data.filesInList);
+      .then((result) => result.data.filesInList)
+      .then((result) => {
+        const { columns } = table;
+        const columnsToAppendString = columns.filter((colum) => colum.appendString);
+        if (Object.keys(columnsToAppendString).length > 0) {
+          return appendStringsToRecord(result, columnsToAppendString);
+        }
+
+        return result;
+      });
     return fetchResult;
   }
 


### PR DESCRIPTION
## Description
This PR addresses the need to append the DRS URL in front of the file ID for the Download Manifest feature. We've introduced a new function called "appendString," which is incorporated under the server-paginated table. Currently, this function is accessible exclusively within the DOWNLOAD_MANIFEST on-click event.

**Fixes:** # [CDS-628](https://tracker.nci.nih.gov/browse/CDS-628)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug Fix: This is a non-breaking change that fixes a specific issue.
- [x] New Feature: This is a non-breaking change that adds new functionality to enhance the user experience.
- [ ] Breaking Change: This is a fix or feature that could potentially disrupt existing functionality.
- [ ] This Change Requires a Documentation Update.

## How Has This Been Tested?
To ensure the integrity of this PR, the following testing procedures have been executed:

- **Manual Testing**: Verified the "appendString" functionality within the DOWNLOAD_MANIFEST on-click event to confirm its proper operation.

These comprehensive testing steps provide confidence in the reliability and robustness of the implemented functionality.
