### PR TITLE
Cds 634 facets sliders crashing

### DIFF
--- a/packages/facet-filter/src/components/facet/FacetView.js
+++ b/packages/facet-filter/src/components/facet/FacetView.js
@@ -52,7 +52,7 @@ const FacetView = ({
    * display checked items on facet collapse
    */
   const { type, facetValues } = facet;
-  const selectedItems = facetValues && facetValues.filter((item) => item.isChecked);
+  const selectedItems = facetValues && facetValues.filter((item) => item && item.isChecked);
   const displayFacet = { ...facet };
   displayFacet.facetValues = selectedItems;
   const isActiveFacet = [...selectedItems].length > 0;

--- a/packages/facet-filter/src/utils/Sort.js
+++ b/packages/facet-filter/src/utils/Sort.js
@@ -5,6 +5,7 @@ export const sortType = {
   ALPHA_NUMERIC: 'ALPHA_NUMERIC',
   CUSTOM_NUMBER: 'CUSTOM_NUMBER',
   RANGE: 'RANGE',
+  NONE: 'NONE',
 };
 
 /**
@@ -45,7 +46,7 @@ export const sortBySection = ({
   count = 'subjects',
 }) => {
   const sortfacetValues = [...facetValues];
-  if (!sortfacetValues) {
+  if (!sortfacetValues || sort_type === sortType.NONE) {
     return facetValues;
   }
   if (sortBy === sortType.NUMERIC) {


### PR DESCRIPTION
## Description

Updated the facets package to avoid crashing when there are two sliders by checking for null values first. And avoiding sorting on Sliders which is unnecessary and can crash when slider values are null

Fixes # CDS-634

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Ran locally tested alongside the corresponding  CDS project frontend-PR
https://github.com/CBIIT/bento-cds-frontend/pull/118