### PR TITLE
cart checks current count before new file for limit

### DIFF
--- a/packages/paginated-table/src/wrapper/components/AddAllFiles/AddAllView.js
+++ b/packages/paginated-table/src/wrapper/components/AddAllFiles/AddAllView.js
@@ -38,11 +38,17 @@ const AddAllFilesComponent = (props) => {
       variables: activeFilters,
       query: addFileQuery,
     });
+    let filesInCart = 0;
+    if (localStorage.getItem('CartFileIds')) {
+      const filesId = JSON.parse(localStorage.getItem('CartFileIds')) || [];
+      filesInCart = filesId.length;
+    }
+
     fileIds().then((response) => {
       const data = response[responseKeys[0]];
       if (data && data.length > 0) {
         const ids = addFilesResponseHandler(response, responseKeys);
-        if (ids.length > maxFileLimit) {
+        if (ids.length + filesInCart > maxFileLimit) {
           setAlterDisplay(true);
         } else {
           setOpen(true);

--- a/packages/paginated-table/src/wrapper/components/AddSelectedFiles/AddSelectedFilesController.js
+++ b/packages/paginated-table/src/wrapper/components/AddSelectedFiles/AddSelectedFilesController.js
@@ -47,10 +47,15 @@ const AddSelectedFilesController = (props) => {
       fileIds: selectedRows,
       query: addFileQuery,
     });
+    let existingIdCount = 0;
+    if (localStorage.getItem('CartFileIds')) {
+      const filesId = JSON.parse(localStorage.getItem('CartFileIds')) || [];
+      existingIdCount = filesId.length;
+    }
 
     fileIds().then((response) => {
       const ids = addFilesResponseHandler(response, responseKeys);
-      if (ids.length >= maxFileLimit) {
+      if (ids.length + existingIdCount >= maxFileLimit) {
         setAlterDisplay(true);
       } else {
         addFiles(ids);

--- a/packages/paginated-table/src/wrapper/components/AddSelectedFiles/AddSelectedFilesController.js
+++ b/packages/paginated-table/src/wrapper/components/AddSelectedFiles/AddSelectedFilesController.js
@@ -47,15 +47,15 @@ const AddSelectedFilesController = (props) => {
       fileIds: selectedRows,
       query: addFileQuery,
     });
-    let existingIdCount = 0;
+    let filesInCart = 0;
     if (localStorage.getItem('CartFileIds')) {
       const filesId = JSON.parse(localStorage.getItem('CartFileIds')) || [];
-      existingIdCount = filesId.length;
+      filesInCart = filesId.length;
     }
 
     fileIds().then((response) => {
       const ids = addFilesResponseHandler(response, responseKeys);
-      if (ids.length + existingIdCount >= maxFileLimit) {
+      if (ids.length + filesInCart >= maxFileLimit) {
         setAlterDisplay(true);
       } else {
         addFiles(ids);


### PR DESCRIPTION
## Description

A user is able to slowly add files to the cart, exceeding the limit and then breaking the cart page. Added a limit to the 'add selected files' button. 

Fixes # CDS-636

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?