### PR TITLE
CTDC: Add Optional Filter Icon and Text under SearchResultsGenerator

### DIFF
--- a/packages/global-search/package.json
+++ b/packages/global-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bento-core/global-search",
-  "version": "1.0.0-ctdc.0",
+  "version": "1.0.0-ctdc.1",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/global-search/src/SearchResults/README.md
+++ b/packages/global-search/src/SearchResults/README.md
@@ -44,6 +44,9 @@ const DEFAULT_CONFIG_SEARCHRESULTS = {
     // The mapping of search result types to JSX components
     // See below for more details
     resultCardMap: {},
+
+    // Whether to display the Filter icon and "FILTER BY" text or not
+    showFilterBy: false,
   },
 
   // Helper functions used by the component

--- a/packages/global-search/src/SearchResults/SearchResultsGenerator.js
+++ b/packages/global-search/src/SearchResults/SearchResultsGenerator.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Box, Tab } from '@material-ui/core';
+import { Box, Grid, Tab } from '@material-ui/core';
 import { TabContext, TabList, TabPanel } from '@material-ui/lab';
 import PaginatedPanel from './components/PaginatedPanel';
 import { DEFAULT_CONFIG_SEARCHRESULTS } from './config';
@@ -35,6 +35,10 @@ export const SearchResultsGenerator = (uiConfig = DEFAULT_CONFIG_SEARCHRESULTS) 
     ? functions.getTabData
     : DEFAULT_CONFIG_SEARCHRESULTS.functions.getTabData;
 
+  const showFilterBy = config && typeof config.showFilterBy === 'boolean'
+    ? config.showFilterBy
+    : DEFAULT_CONFIG_SEARCHRESULTS.config.showFilterBy;
+
   return {
     SearchResults: (props) => {
       const { searchText } = props;
@@ -53,24 +57,42 @@ export const SearchResultsGenerator = (uiConfig = DEFAULT_CONFIG_SEARCHRESULTS) 
       return (
         <TabContext value={tabValue}>
           <Box sx={{ borderBottom: '1px solid #828282' }}>
-            <TabList onChange={onChangeWrapper} aria-label="tabs" classes={{ root: classes.tabContainter, indicator: classes.indicator }}>
-              {tabs.map((prop, idx) => (
-                <Tab
-                  key={`result_tab_${idx}`}
-                  classes={prop.classes}
-                  label={(
-                    <span>
-                      <span id={`global_search_tab_label_${idx}`}>
-                        {typeof prop.name === 'function' ? prop.name() : prop.name}
-                      </span>
-                      {' '}
-                      <span id={`global_search_tab_count_${idx}`}>{prop.count}</span>
-                    </span>
-                  )}
-                  value={prop.value}
-                />
-              ))}
-            </TabList>
+            <Grid container alignItems="center" justifyContent="center">
+              {showFilterBy && (
+                <>
+                  <Grid item className={classes.filterByIconContainer}>
+                    <img
+                      src="https://raw.githubusercontent.com/CBIIT/datacommons-assets/global-search/bento/images/icons/svgs/filterByIcon.svg"
+                      alt="Filter By Icon"
+                      className={classes.filterByIcon}
+                    />
+                  </Grid>
+                  <Grid item className={classes.filterByTextContainer}>
+                    <span className={classes.filterByText}>FILTER BY:</span>
+                  </Grid>
+                </>
+              )}
+              <Grid item flexGrow={1}>
+                <TabList onChange={onChangeWrapper} aria-label="tabs" classes={{ root: classes.tabContainter, indicator: classes.indicator }}>
+                  {tabs.map((prop, idx) => (
+                    <Tab
+                      key={`result_tab_${idx}`}
+                      classes={prop.classes}
+                      label={(
+                        <span>
+                          <span id={`global_search_tab_label_${idx}`}>
+                            {typeof prop.name === 'function' ? prop.name() : prop.name}
+                          </span>
+                          {' '}
+                          <span id={`global_search_tab_count_${idx}`}>{prop.count}</span>
+                        </span>
+                      )}
+                      value={prop.value}
+                    />
+                  ))}
+                </TabList>
+              </Grid>
+            </Grid>
           </Box>
           {tabs.map((prop, idx) => (
             <TabPanel value={prop.value} key={`result_panel_${idx}`}>

--- a/packages/global-search/src/SearchResults/config.js
+++ b/packages/global-search/src/SearchResults/config.js
@@ -15,6 +15,9 @@ export const DEFAULT_CONFIG_SEARCHRESULTS = {
 
     // The mapping of search result types to JSX components
     resultCardMap: {},
+
+    // Whether to display the Filter icon and "FILTER BY" text or not
+    showFilterBy: false,
   },
 
   // Helper functions used by the component


### PR DESCRIPTION
- Introduces optional filter icon and "FILTER BY" text adjacent to search categories using `showFilterBy`
- By defaults `showFilterBy` is **false** to maintain compatibility with existing BENTO feature