### PR TITLE
fix justifyContent

### DIFF
--- a/packages/facet-filter/src/components/facet/FacetStyle.js
+++ b/packages/facet-filter/src/components/facet/FacetStyle.js
@@ -38,7 +38,7 @@ export default () => ({
     // marginLeft: '-5px',
     display: 'flex',
     alignItems: 'center',
-    justifyContent: 'center',
+    justifyContent: 'space-around',
   },
   sortGroupIcon: {
     cursor: 'pointer',


### PR DESCRIPTION
## Description
-  "sort by counts" and "sort by alphabet"  move to the different lines when zoom out.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Visually on ICDC.