### PR TITLE
Added Custom Styling for table pagination and fixed URLs

### DIFF
--- a/packages/table/src/ExtendedView.js
+++ b/packages/table/src/ExtendedView.js
@@ -55,7 +55,7 @@ const ExtendedView = ({
       )}
       {
           (pagination) && (
-            <div className="downloadArea" style={downloadAreaStyle}>
+            <div className="downloadArea" style={(table.paginationCustomStyle && table.paginationCustomStyle.topPagination) ? table.paginationCustomStyle.topPagination : downloadAreaStyle}>
               <CustomPagination
                 customTheme={customTheme.tblTopPgn}
                 rowsPerPageOptions={[10, 25, 50, 100]}

--- a/packages/table/src/TableView.js
+++ b/packages/table/src/TableView.js
@@ -94,7 +94,7 @@ const TableView = ({
         table={table}
       />
     )}
-    <div className="downloadArea" style={table.paginationAPIField === 'filesInList' ? cartDownloadAreaStyle : downloadAreaStyle}>
+    <div className="downloadArea" style={table.paginationAPIField === 'filesInList' ? cartDownloadAreaStyle : (table.paginationCustomStyle && table.paginationCustomStyle.bottomPagination) ? table.paginationCustomStyle.bottomPagination : downloadAreaStyle}>
       <CustomPagination
         customTheme={themeConfig.tblPgn}
         rowsPerPageOptions={[10, 25, 50, 100]}

--- a/packages/table/src/body/components/CustomLinkView.js
+++ b/packages/table/src/body/components/CustomLinkView.js
@@ -12,7 +12,7 @@ const CustomLinkView = ({
   row,
 }) => {
   const { rootPath, pathParams } = column?.linkAttr;
-  const url = pathParams.map((attr) => `#${rootPath}/`.concat(row[attr]));
+  const url = pathParams.map((attr) => `${rootPath}/`.concat(row[attr]));
   return (
     <Link href={url} className={cellTypes.LINK}>
       <Typography>


### PR DESCRIPTION
## Description

Styling for the paginations of the table is now accessible from the front.
The URLs for C3DC do not function with the '#' character, now removed.

Fixes # (issue)

[C3DC-509](https://tracker.nci.nih.gov/browse/C3DC-509)

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Ran locally