### PR TITLE
 Pagination Focus is going to bottom of the page instead of top.

### DIFF
--- a/packages/bento-frontend/src/content/dev/aboutPagesContent.yaml
+++ b/packages/bento-frontend/src/content/dev/aboutPagesContent.yaml
@@ -10,8 +10,8 @@
   content:
     - paragraph: "Bento is a modular, data agnostic, cloud-enable software framework for building data sharing platforms, for life science and clinical research. Instructions on using the Bento framework to set up your own platform may be found $$[here](https://cbiit.github.io/bento-docs/)."
     - paragraph: "All code necessary to use Bento is provided in the form of Docker containers. However, we do provide our code to the public for research, usage, forking and pull requests. Here are the repos for:"
-    - paragraph: "•	Core Data Model: $$[https://github.com/CBIIT/bento-model](https://github.com/CBIIT/bento-model)$$"
-    - paragraph: "•	Frontend: $$[https://github.com/CBIIT/bento-frontend](https://github.com/CBIIT/bento-frontend)"
-    - paragraph: "•	File and Data Loaders: $$[https://github.com/CBIIT/icdc-dataloader](https://github.com/CBIIT/icdc-dataloader)"
+    - paragraph: "• Core Data Model: $$[https://github.com/CBIIT/bento-model](https://github.com/CBIIT/bento-model)$$"
+    - paragraph: "• Frontend: $$[https://github.com/CBIIT/bento-frontend](https://github.com/CBIIT/bento-frontend)"
+    - paragraph: "• File and Data Loaders: $$[https://github.com/CBIIT/icdc-dataloader](https://github.com/CBIIT/icdc-dataloader)"
   secondaryZoomImageTitle: "The Bento Core Data Model"
   secondaryZoomImage: 'https://cbiit.github.io/bento-model/model-desc/bento-model.svg'

--- a/packages/global-search/src/SearchResults/components/PaginatedPanel.js
+++ b/packages/global-search/src/SearchResults/components/PaginatedPanel.js
@@ -56,9 +56,11 @@ const PaginatedPanel = (props) => {
     if (page >= Math.ceil(count / pageSize)) {
       return;
     }
-
+    
     onChange(page + 1);
     setPage(page + 1);
+    scrollToTop();
+
   };
 
   const onPrevious = () => {
@@ -66,8 +68,10 @@ const PaginatedPanel = (props) => {
       return;
     }
 
+    
     onChange(page - 1);
     setPage(page - 1);
+    scrollToTop();
   };
 
   const scrollToTop = () => {


### PR DESCRIPTION
## Description

 Fixed issue:
 
Navigating the Clinical Trial Data Commons site's Global Search, selecting page 6 positions the focus at the top as expected. However, clicking "Next" redirects the focus to the bottom, contrary to expectations for it to stay at the top.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.


- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?