### PR TITLE
filters out duplicates before sending IDs to card reducer

### DIFF
--- a/packages/paginated-table/src/wrapper/components/util.js
+++ b/packages/paginated-table/src/wrapper/components/util.js
@@ -16,7 +16,7 @@ const addFilesResponseHandler = (response, responseKeys = []) => {
         }
         return acc;
       }, []);
-      return ids;
+      return [...new Set(ids)];
     }
     return [];
   }


### PR DESCRIPTION
## Description

The list of IDs here contain duplicates. The cart reducer (which they're passed to) expects it to be unique. So we first remove the duplicates

Fixes # [CDS-915](https://tracker.nci.nih.gov/browse/CDS-915)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Locally