### PR TITLE
Now checks if there is a addFileQuery, can ids pull from variables

### DIFF
--- a/packages/paginated-table/src/wrapper/components/AddSelectedFiles/AddSelectedFilesController.js
+++ b/packages/paginated-table/src/wrapper/components/AddSelectedFiles/AddSelectedFilesController.js
@@ -41,20 +41,36 @@ const AddSelectedFilesController = (props) => {
 
   // add selected files id
   const addSelectedFiles = () => {
-    const fileIds = getFilesID({
-      client,
-      variables,
-      fileIds: selectedRows,
-      query: addFileQuery,
-    });
-    let filesInCart = 0;
-    if (localStorage.getItem('CartFileIds')) {
-      const filesId = JSON.parse(localStorage.getItem('CartFileIds')) || [];
-      filesInCart = filesId.length;
-    }
+    if (addFileQuery) {
+      const fileIds = getFilesID({
+        client,
+        variables,
+        fileIds: selectedRows,
+        query: addFileQuery,
+      });
+      let filesInCart = 0;
+      if (localStorage.getItem('CartFileIds')) {
+        const filesId = JSON.parse(localStorage.getItem('CartFileIds')) || [];
+        filesInCart = filesId.length;
+      }
 
-    fileIds().then((response) => {
-      const ids = addFilesResponseHandler(response, responseKeys);
+      fileIds().then((response) => {
+        const ids = addFilesResponseHandler(response, responseKeys);
+        if (ids.length + filesInCart >= maxFileLimit) {
+          setAlterDisplay(true);
+        } else {
+          addFiles(ids);
+          setOpenSnackbar(true);
+          dispatch(onRowSeclect([]));
+        }
+      });
+    } else {
+      const ids = variables[dataKey];
+      let filesInCart = 0;
+      if (localStorage.getItem('CartFileIds')) {
+        const filesId = JSON.parse(localStorage.getItem('CartFileIds')) || [];
+        filesInCart = filesId.length;
+      }
       if (ids.length + filesInCart >= maxFileLimit) {
         setAlterDisplay(true);
       } else {
@@ -62,7 +78,7 @@ const AddSelectedFilesController = (props) => {
         setOpenSnackbar(true);
         dispatch(onRowSeclect([]));
       }
-    });
+    }
   };
 
   return (


### PR DESCRIPTION
## Description

Some tables in CDS already contain the ids needed and this modification allows it to bypass the query and pull the IDs directly from the variables. Sending them directly to the cart

Fixes # (issue)
[CDS-939](https://tracker.nci.nih.gov/browse/CDS-939)
[CDS-945](https://tracker.nci.nih.gov/browse/CDS-945)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Locally