### PR TITLE
CDS-968 Fix Inconsistent Table Tooltips

### DIFF
--- a/packages/table/src/header/CustomCell.js
+++ b/packages/table/src/header/CustomCell.js
@@ -43,7 +43,7 @@ const CustomHeaderCell = ({
     }
     // return default view
     return <>{children}</>;
-  }, []);
+  }, [components, tooltipText]);
 
   return (
     <TableCell


### PR DESCRIPTION
## Description

This was an existing issue where the tooltips useCallback was missing deps causing inconsistent tooltip texts being displayed. The issue was observed when a hidden table column was enabled, it had the tooltip of a different table column.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Tested manually on CDS.