### PR TITLE
CDS-991 Fix Empty manifest includes BOM

### DIFF
--- a/packages/cart/src/utils.js
+++ b/packages/cart/src/utils.js
@@ -50,7 +50,8 @@ export function downloadJson({
 }) {
   const jsonse = JSON.stringify(tableData);
   const csv = convertToCSV(jsonse, comment, manifestData.keysToInclude, manifestData.header);
-  const exportData = new Blob([`\uFEFF${csv}`], { type: 'text/csv;charset=utf-8' });
+  const blobPart = csv && csv.length > 0 ? `\uFEFF${csv}` : '';
+  const exportData = new Blob([blobPart], { type: 'text/csv;charset=utf-8' });
   const JsonURL = window.URL.createObjectURL(exportData);
   let tempLink = '';
   tempLink = document.createElement('a');


### PR DESCRIPTION
## Description

The Byte Order Mark was being concatenated regardless if the csv had content or not. This caused an issue when there was no content, the BOM would be the only thing displaying in the downloaded CSV file. Updated to only include the BOM when content exists.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tested manually on CDS.