### PR TITLE
Add option to display custom slider label

### DIFF
--- a/packages/facet-filter/README.md
+++ b/packages/facet-filter/README.md
@@ -95,6 +95,8 @@ export const facetsConfig = [{
     minLowerBound: 0,  
     maxUpperBound: 100,   
     quantifier: 'Years',
+    CustomLowerUpperBound: CustomLowerUpperBound, // Custom component for displaying lower and upper bounds
+    CustomSliderValue: CustomSliderValue, // Custom component for displaying slider value
 ].
 ```
 1. **apiForFiltering** refers to object key for retrieving name and subjects count from query response (DASHBOARD_QUERY)

--- a/packages/facet-filter/package.json
+++ b/packages/facet-filter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bento-core/facet-filter",
-  "version": "1.0.1-ctdc.2",
+  "version": "1.0.1-ctdc.3",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/facet-filter/package.json
+++ b/packages/facet-filter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bento-core/facet-filter",
-  "version": "1.0.1-ctdc.3",
+  "version": "1.0.1-popsci.1",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/facet-filter/src/components/inputs/slider/SliderView.js
+++ b/packages/facet-filter/src/components/inputs/slider/SliderView.js
@@ -14,7 +14,15 @@ const SliderView = ({
   onSliderToggle,
   filterState,
 }) => {
-  const { minLowerBound, maxUpperBound, quantifier, datafield, facetValues } = facet;
+  const {
+    minLowerBound,
+    maxUpperBound,
+    quantifier,
+    datafield,
+    facetValues,
+    CustomLowerUpperBound,
+    CustomSliderValue,
+  } = facet;
   const lowerBoundValue = facetValues[0];
   const upperBoundValue = facetValues[1];
 
@@ -99,24 +107,26 @@ const SliderView = ({
             }}
           />
         </div>
-        <Box className={classes.lowerUpperBound}>
-          <Typography className={classes.lowerBound}>
-            {minLowerBound}
-          </Typography>
-          <Typography className={classes.upperBound}>
-            {maxUpperBound}
-          </Typography>
-        </Box>
+        {typeof CustomLowerUpperBound === 'function' ? (
+          CustomLowerUpperBound({ minLowerBound, maxUpperBound, classes })
+        ) : (
+          <Box className={classes.lowerUpperBound}>
+            <Typography className={classes.lowerBound}>
+              {minLowerBound}
+            </Typography>
+            <Typography className={classes.upperBound}>
+              {maxUpperBound}
+            </Typography>
+          </Box>
+        )}
       </div>
       {/* Change to red if invalid range */}
-      {
-        (sliderValue[0] > minLowerBound || sliderValue[1] < maxUpperBound)
-        && (
-          <Typography
-            className={isValid()
-              ? classes.sliderText
-              : classes.invalidSliderText}
-          >
+      {typeof CustomSliderValue === 'function' ? (
+        CustomSliderValue({
+          sliderValue, minLowerBound, maxUpperBound, isValid, quantifier, classes })
+      ) : (
+        (sliderValue[0] > minLowerBound || sliderValue[1] < maxUpperBound) && (
+          <Typography className={isValid() ? classes.sliderText : classes.invalidSliderText}>
             {sliderValue[0]}
             {' - '}
             {sliderValue[1]}
@@ -124,7 +134,7 @@ const SliderView = ({
             {quantifier}
           </Typography>
         )
-      }
+      )}
     </>
   );
 };


### PR DESCRIPTION
## Description
- Introduced two new props, `CustomLowerUpperBound` and `CustomSliderValue`, allowing users to pass custom labels for the slider's lower/upper bounds and current value.

- Falls back to standard labels when custom props are absent.

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update