### PR TITLE
Added span to allow for tooltip on disabled button

### DIFF
--- a/packages/paginated-table/src/wrapper/components/AddSelectedFiles/AddSelectedFilesView.js
+++ b/packages/paginated-table/src/wrapper/components/AddSelectedFiles/AddSelectedFilesView.js
@@ -61,14 +61,17 @@ const AddSelectedFileComponent = (props) => {
         }}
         {...tooltipProps}
       >
-        <Button
-          onClick={addFiles}
-          className={clsName}
-          disableRipple
-          disabled={disabled}
-        >
-          {title}
-        </Button>
+        <span className={classes.customTooltipSpan}>
+          <Button
+            onClick={addFiles}
+            className={clsName}
+            disableRipple
+            disabled={disabled}
+            style={{ margin: '0px' }}
+          >
+            {title}
+          </Button>
+        </span>
       </ToolTip>
       {tooltipCofig && (<ToolTipView classes={classes} {...props} />)}
     </>


### PR DESCRIPTION
## Description

Wrapping the button with a span element allows for tooltip to be viewable on hover

Fixes # (issue)

[CDS-1051](https://tracker.nci.nih.gov/browse/CDS-1051)

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Locally