### PR TITLE
CDS Facet dropdown fix

### DIFF
--- a/packages/local-find/src/SearchBox/SearchBoxGenerator.js
+++ b/packages/local-find/src/SearchBox/SearchBoxGenerator.js
@@ -159,7 +159,13 @@ export const SearchBoxGenerator = (uiConfig = DEFAULT_CONFIG) => {
                   {...params}
                   classes={classes}
                   placeholder={inputPlaceholder}
-                  inputProps={{ 'aria-label': ariaLabel }}
+                  InputProps={{
+                    ...params.InputProps,
+                    inputProps: {
+                      ...params.inputProps,
+                      'aria-label': ariaLabel,
+                    },
+                  }}
                 />
               )}
             />


### PR DESCRIPTION
## Description

Used wrong input props to provide aria-label. Caused MUI to crash site when dropdown is opened.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Test manually in CDS local.