### PR TITLE
CDS-1026 CDS Facet checkbox name word break

### DIFF
--- a/packages/facet-filter/src/components/inputs/checkbox/CheckboxStyle.js
+++ b/packages/facet-filter/src/components/inputs/checkbox/CheckboxStyle.js
@@ -28,5 +28,6 @@ export default () => ({
     marginTop: '1.5px',
     fontFamily: 'Nunito',
     lineHeight: '120%',
+    wordBreak: 'break-word',
   },
 });


### PR DESCRIPTION
## Description

Adds word break to the checkbox labels within the facet filters.

Fixes # [CDS-1026](https://tracker.nci.nih.gov/browse/CDS-1026)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tested manually in CDS local.