### PR TITLE
updated font size for explore page

### DIFF
--- a/packages/facet-filter/src/components/facet/FacetStyle.js
+++ b/packages/facet-filter/src/components/facet/FacetStyle.js
@@ -40,8 +40,8 @@ export default () => ({
   sortGroupItem: {
     cursor: 'pointer',
     fontFamily: 'Nunito',
-    fontSize: '10px',
-    marginRight: '32px',
+    fontSize: '11px',
+    marginRight: '31px',
   },
   NonSortGroup: {
     marginBottom: '5px',
@@ -51,13 +51,13 @@ export default () => ({
   },
   NonSortGroupItem: {
     fontFamily: 'Nunito',
-    fontSize: '10px',
-    marginRight: '32px',
+    fontSize: '11px',
+    marginRight: '31px',
   },
   sortGroupItemCounts: {
     cursor: 'pointer',
     fontFamily: 'Nunito',
-    fontSize: '10px',
+    fontSize: '11px',
     float: 'right',
     marginRight: '10px',
     marginTop: '5px',


### PR DESCRIPTION
## Description

Font size too small for 508 compliance, updated font size for facets.

Fixes # (issue)
[CDS-1094](https://tracker.nci.nih.gov/browse/CDS-1094)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
locally