### PR TITLE
CTDC-1578: Add an Option to Show/Hide "Sort by Count" in Facets

### DIFF
--- a/packages/facet-filter/package.json
+++ b/packages/facet-filter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bento-core/facet-filter",
-  "version": "1.0.1-ctdc.2",
+  "version": "1.0.1-ctdc.3",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/facet-filter/src/components/facet/FacetView.js
+++ b/packages/facet-filter/src/components/facet/FacetView.js
@@ -51,7 +51,7 @@ const FacetView = ({
   /**
    * display checked items on facet collapse
    */
-  const { type, facetValues } = facet;
+  const { type, facetValues, displayFacetCount = true } = facet;
   const selectedItems = facetValues && facetValues.filter((item) => item.isChecked);
   const displayFacet = { ...facet };
   displayFacet.facetValues = selectedItems;
@@ -135,18 +135,20 @@ const FacetView = ({
             >
               Sort alphabetically
             </span>
-            <span
-              className={
-                    clsx(classes.sortGroupItemCounts, {
-                      [classes.highlight]: sortBy === sortType.NUMERIC,
-                    })
-                  }
-              onClick={() => {
-                onSortFacet(sortType.NUMERIC);
-              }}
-            >
-              Sort by count
-            </span>
+            { displayFacetCount && (
+              <span
+                className={
+                      clsx(classes.sortGroupItemCounts, {
+                        [classes.highlight]: sortBy === sortType.NUMERIC,
+                      })
+                    }
+                onClick={() => {
+                  onSortFacet(sortType.NUMERIC);
+                }}
+              >
+                Sort by count
+              </span>
+            )}
           </>
           )}
           </div>

--- a/packages/facet-filter/src/components/inputs/checkbox/CheckboxView.js
+++ b/packages/facet-filter/src/components/inputs/checkbox/CheckboxView.js
@@ -42,6 +42,7 @@ const CheckBoxView = ({
     count = 'subjects',
     customCount = (text) => `(${text})`,
     defaultValue = '',
+    displayFacetCount = true,
   } = facet;
 
   const indexType = index % 2 === 0 ? 'Even' : 'Odd';
@@ -115,14 +116,16 @@ const CheckBoxView = ({
           <LabelComponent />
         )}
         <ListItemText className={`${checkedSection}_md_space`} />
-        <Typography
-          className={clsx(`${checkedSection}Subjects`, {
-            [`${checkedSection}SubjectUnChecked`]: !isChecked,
-            [`${checkedSection}SubjectChecked`]: isChecked,
-          })}
-        >
-          {customCount(checkboxItem[count] || 0)}
-        </Typography>
+        { displayFacetCount && (
+          <Typography
+            className={clsx(`${checkedSection}Subjects`, {
+              [`${checkedSection}SubjectUnChecked`]: !isChecked,
+              [`${checkedSection}SubjectChecked`]: isChecked,
+            })}
+          >
+            {customCount(checkboxItem[count] || 0)}
+          </Typography>
+        )}
       </ListItem>
       <Divider
         style={{


### PR DESCRIPTION
## Description

Introduced a `displayFacetCount` option to control the visibility of the "Sort by Count" feature and Facet Count column in Facets. By default, `displayFacetCount` is set to `true`, ensuring the feature is displayed unless explicitly disabled.

Usage Example: 
`/bento-frontend/packages/bento-frontend/src/bento/dashTemplate.js`

     export const facetsConfig = [
        {
            section: CASES,
            label: 'Program',
            apiPath: 'subjectCountByProgram',
            apiForFiltering: 'filterSubjectCountByProgram',
            datafield: 'programs',
            field: GROUP,
            type: InputTypes.CHECKBOX,
            sort_type: sortType.ALPHABET,
            show: true,
    
            displayFacetCount: false // Hides "Sort by Count" and the count column
        },
        {...}
        ...
    ];
Fixes # [CTDC-1578](https://tracker.nci.nih.gov/browse/CTDC-1578)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)