### PR TITLE
Updated pagination and search components to be hidden to avoid confusion

### DIFF
--- a/packages/global-search/src/SearchBar/styles.js
+++ b/packages/global-search/src/SearchBar/styles.js
@@ -66,6 +66,9 @@ export const DEFAULT_STYLES = makeStyles({
     '& .MuiOutlinedInput-root': {
       '& fieldset': {
         borderColor: '#4A8ECB',
+        '& legend': {
+          visibility: 'hidden',
+        },
       },
       '&:hover fieldset': {
         borderColor: '#4A8ECB',

--- a/packages/table/src/pagination/CustomPagination.js
+++ b/packages/table/src/pagination/CustomPagination.js
@@ -51,7 +51,15 @@ const CustomPagination = ({
       onPageChange={onPageChange}
       onRowsPerPageChange={onRowsPerPageChange}
       labelRowsPerPage={<span id="rows-per-page-label">Rows per page:</span>}
-      SelectProps={{ inputProps: { 'aria-label': 'rows per page dropdown selector', 'aria-labelledby': 'rows-per-page-label' } }}
+      SelectProps={{
+        inputProps: {
+          'aria-label': 'rows per page dropdown selector',
+          'aria-labelledby': 'rows-per-page-label',
+          style: {
+            visibility: 'hidden',
+          },
+        },
+      }}
     />
   </ThemeProvider>
 );


### PR DESCRIPTION
## Description

Two additional components that require 508 changes were founds that are considered 'Global' (appear on multiple pages).
 
There were flags for color contrast issues for the search bar and the pagination of tables. These were false flags because they flagged empty contents. The resolution was to make these components not-visible (they had no contents anyways) so that the 508 software checkers wouldn't flag them.

Fixes [CDS-1152](https://tracker.nci.nih.gov/browse/CDS-1152)

## Type of change
Updated visibility to hidden for empty component for 508 compliance

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
locally