### PR TITLE
Shortened the local find participant previews

### DIFF
--- a/packages/local-find/src/SearchBox/components/SearchList.js
+++ b/packages/local-find/src/SearchBox/components/SearchList.js
@@ -29,49 +29,30 @@ const SearchList = (props) => {
 
   return (
     <List classes={{ padding: classes.listPadding }} id={id}>
-      {(items || []).length > 3 ? (
+      {items.slice(0, 3).map((item, index) => (
         <>
-          {/* Display first three items */}
-          {items.slice(0, 3).map((item, index) => (
-            <>
-              <Divider className={classes.divider} />
-              <ListItem classes={{ gutters: classes.listItemGutters }} key={index}>
-                <div className={classes.searchResultDetailText}>
-                  <span>
-                    {item}
-                  </span>
-                </div>
-                <div className={classes.deleteIcon} onClick={() => deleteWrapper(item)}>
-                  <img src="https://raw.githubusercontent.com/CBIIT/datacommons-assets/main/bento/images/icons/svgs/LocalFindCaseDeleteIcon.svg" alt="close icon" className={classes.closeRoot} />
-                </div>
-              </ListItem>
-            </>
-          ))}
-          {/* Add an ellipsis after the third item */}
           <Divider className={classes.divider} />
-          <ListItem classes={{ gutters: classes.listItemGutters }} key={3}>
+          <ListItem classes={{ gutters: classes.listItemGutters }} key={index}>
+            <div className={classes.searchResultDetailText}>
+              <span>
+                {item}
+              </span>
+            </div>
+            <div className={classes.deleteIcon} onClick={() => deleteWrapper(item)}>
+              <img src="https://raw.githubusercontent.com/CBIIT/datacommons-assets/main/bento/images/icons/svgs/LocalFindCaseDeleteIcon.svg" alt="close icon" className={classes.closeRoot} />
+            </div>
+          </ListItem>
+        </>
+      ))}
+      {items.length > 3 && (
+        <>
+          <Divider className={classes.divider} />
+          <ListItem classes={{ gutters: classes.listItemGutters }} key="ellipsis">
             <div className={classes.searchResultDetailText}>
               <span>...</span>
             </div>
           </ListItem>
         </>
-      ) : (
-        // Display all items if there are 3 or fewer
-        (items || []).map((item, index) => (
-          <>
-            <Divider className={classes.divider} />
-            <ListItem classes={{ gutters: classes.listItemGutters }} key={index}>
-              <div className={classes.searchResultDetailText}>
-                <span>
-                  {item}
-                </span>
-              </div>
-              <div className={classes.deleteIcon} onClick={() => deleteWrapper(item)}>
-                <img src="https://raw.githubusercontent.com/CBIIT/datacommons-assets/main/bento/images/icons/svgs/LocalFindCaseDeleteIcon.svg" alt="close icon" className={classes.closeRoot} />
-              </div>
-            </ListItem>
-          </>
-        ))
       )}
     </List>
   );

--- a/packages/local-find/src/SearchBox/components/SearchList.js
+++ b/packages/local-find/src/SearchBox/components/SearchList.js
@@ -49,7 +49,7 @@ const SearchList = (props) => {
           ))}
           {/* Add an ellipsis after the third item */}
           <Divider className={classes.divider} />
-          <ListItem classes={{ gutters: classes.listItemGutters }}>
+          <ListItem classes={{ gutters: classes.listItemGutters }} key={3}>
             <div className={classes.searchResultDetailText}>
               <span>...</span>
             </div>

--- a/packages/local-find/src/SearchBox/components/SearchList.js
+++ b/packages/local-find/src/SearchBox/components/SearchList.js
@@ -29,21 +29,50 @@ const SearchList = (props) => {
 
   return (
     <List classes={{ padding: classes.listPadding }} id={id}>
-      {(items || []).reverse().map((item, index) => (
+      {(items || []).length > 3 ? (
         <>
+          {/* Display first three items */}
+          {items.slice(0, 3).map((item, index) => (
+            <>
+              <Divider className={classes.divider} />
+              <ListItem classes={{ gutters: classes.listItemGutters }} key={index}>
+                <div className={classes.searchResultDetailText}>
+                  <span>
+                    {item}
+                  </span>
+                </div>
+                <div className={classes.deleteIcon} onClick={() => deleteWrapper(item)}>
+                  <img src="https://raw.githubusercontent.com/CBIIT/datacommons-assets/main/bento/images/icons/svgs/LocalFindCaseDeleteIcon.svg" alt="close icon" className={classes.closeRoot} />
+                </div>
+              </ListItem>
+            </>
+          ))}
+          {/* Add an ellipsis after the third item */}
           <Divider className={classes.divider} />
-          <ListItem classes={{ gutters: classes.listItemGutters }} key={index}>
+          <ListItem classes={{ gutters: classes.listItemGutters }}>
             <div className={classes.searchResultDetailText}>
-              <span>
-                {item}
-              </span>
-            </div>
-            <div className={classes.deleteIcon} onClick={() => deleteWrapper(item)}>
-              <img src="https://raw.githubusercontent.com/CBIIT/datacommons-assets/main/bento/images/icons/svgs/LocalFindCaseDeleteIcon.svg" alt="close icon" className={classes.closeRoot} />
+              <span>...</span>
             </div>
           </ListItem>
         </>
-      ))}
+      ) : (
+        // Display all items if there are 3 or fewer
+        (items || []).map((item, index) => (
+          <>
+            <Divider className={classes.divider} />
+            <ListItem classes={{ gutters: classes.listItemGutters }} key={index}>
+              <div className={classes.searchResultDetailText}>
+                <span>
+                  {item}
+                </span>
+              </div>
+              <div className={classes.deleteIcon} onClick={() => deleteWrapper(item)}>
+                <img src="https://raw.githubusercontent.com/CBIIT/datacommons-assets/main/bento/images/icons/svgs/LocalFindCaseDeleteIcon.svg" alt="close icon" className={classes.closeRoot} />
+              </div>
+            </ListItem>
+          </>
+        ))
+      )}
     </List>
   );
 };


### PR DESCRIPTION
## Description

The ordering of the list is no longer reversed. The logic checks if we have more than 3 participants, if so the fourth one will be an elipsis. Else render the 3 of fewer entries as normal.

Fixes [CDS-1186](https://tracker.nci.nih.gov/browse/CDS-1186)

## Type of change



- [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

Locally