### PR TITLE
CTDC-1548: Add customTableHeader prop

### DIFF
--- a/packages/paginated-table/package.json
+++ b/packages/paginated-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bento-core/paginated-table",
-  "version": "1.0.1-ctdc.7",
+  "version": "1.0.1-ctdc.8",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/paginated-table/src/table/PaginatedTable.js
+++ b/packages/paginated-table/src/table/PaginatedTable.js
@@ -23,6 +23,7 @@ const PaginatedTable = ({
   server = true,
   tblRows = [],
   paginationOptions = {},
+  TableHeaderRenderer,
 }) => {
   /**
   * Initailize useReducer state
@@ -165,6 +166,7 @@ const PaginatedTable = ({
           onSortByColumn={customizeSortByColumn || handleSortByColumn}
           onColumnViewChange={customizeColumnViewChange || handleColumnViewChange}
           themeConfig={themeConfig}
+          TableHeaderRenderer={TableHeaderRenderer}
         />
       </>
     );
@@ -195,6 +197,7 @@ const PaginatedTable = ({
         onSortByColumn={customizeSortByColumn || handleSortByColumn}
         onColumnViewChange={customizeColumnViewChange || handleColumnViewChange}
         themeConfig={themeConfig}
+        TableHeaderRenderer={TableHeaderRenderer}
       />
     </>
   );

--- a/packages/paginated-table/src/table/PaginatedTable.js
+++ b/packages/paginated-table/src/table/PaginatedTable.js
@@ -23,7 +23,7 @@ const PaginatedTable = ({
   server = true,
   tblRows = [],
   paginationOptions = {},
-  TableHeaderRenderer,
+  customTableHeader,
 }) => {
   /**
   * Initailize useReducer state
@@ -166,7 +166,7 @@ const PaginatedTable = ({
           onSortByColumn={customizeSortByColumn || handleSortByColumn}
           onColumnViewChange={customizeColumnViewChange || handleColumnViewChange}
           themeConfig={themeConfig}
-          TableHeaderRenderer={TableHeaderRenderer}
+          customTableHeader={customTableHeader}
         />
       </>
     );
@@ -197,7 +197,7 @@ const PaginatedTable = ({
         onSortByColumn={customizeSortByColumn || handleSortByColumn}
         onColumnViewChange={customizeColumnViewChange || handleColumnViewChange}
         themeConfig={themeConfig}
-        TableHeaderRenderer={TableHeaderRenderer}
+        customTableHeader={customTableHeader}
       />
     </>
   );

--- a/packages/paginated-table/src/table/README.md
+++ b/packages/paginated-table/src/table/README.md
@@ -58,7 +58,7 @@ import TableView from 'bento-core/PaginationTable/PaginatedTable';
   activeFilters={activeFilters}
   totalRowCount={dashboardStats[config.count]}
   activeTab={activeTab}
-  TableHeaderRenderer={TableHeaderRenderer}
+  customTableHeader={CustomTableHeader}
 /> 
 ```
 
@@ -70,7 +70,7 @@ import TableView from 'bento-core/PaginationTable/PaginatedTable';
 | themeConfig | FALSE | override style with themeprovider use ClassName provided by bento-core table to apply style (refer to class name table) | |
 | totalRowCount | TRUE | Total row cound for (Cases, Samples, Files), update based on filter event | |
 | activeTab | TRUE | prevents http call for inactive tabs (dashboard) /set true to myFile cart | |
-| TableHeaderRenderer | FALSE | Customizable table header that replaces the default `TableHeader` | |
+| customTableHeader | FALSE | Customizable table header that replaces the default `TableHeader` | |
 
 ## 3 Table component themeConfig Configuration
 ```

--- a/packages/paginated-table/src/table/README.md
+++ b/packages/paginated-table/src/table/README.md
@@ -58,6 +58,7 @@ import TableView from 'bento-core/PaginationTable/PaginatedTable';
   activeFilters={activeFilters}
   totalRowCount={dashboardStats[config.count]}
   activeTab={activeTab}
+  TableHeaderRenderer={TableHeaderRenderer}
 /> 
 ```
 
@@ -69,6 +70,7 @@ import TableView from 'bento-core/PaginationTable/PaginatedTable';
 | themeConfig | FALSE | override style with themeprovider use ClassName provided by bento-core table to apply style (refer to class name table) | |
 | totalRowCount | TRUE | Total row cound for (Cases, Samples, Files), update based on filter event | |
 | activeTab | TRUE | prevents http call for inactive tabs (dashboard) /set true to myFile cart | |
+| TableHeaderRenderer | FALSE | Customizable table header that replaces the default `TableHeader` | |
 
 ## 3 Table component themeConfig Configuration
 ```

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bento-core/table",
-  "version": "1.0.1-ctdc.5",
+  "version": "1.0.1-ctdc.6",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/table/src/TableView.js
+++ b/packages/table/src/TableView.js
@@ -39,7 +39,7 @@ const TableView = ({
   themeConfig = {},
   queryVariables,
   server,
-  TableHeaderRenderer,
+  customTableHeader: CustomTableHeader = TableHeader,
 }) => (
   <>
     <ExtendedView
@@ -64,8 +64,8 @@ const TableView = ({
     >
       <Table>
         {
-          TableHeaderRenderer ? (
-            <TableHeaderRenderer
+          CustomTableHeader ? (
+            <CustomTableHeader
               customTheme={themeConfig.tblHeader}
               table={table}
               rows={tableRows}

--- a/packages/table/src/TableView.js
+++ b/packages/table/src/TableView.js
@@ -39,6 +39,7 @@ const TableView = ({
   themeConfig = {},
   queryVariables,
   server,
+  TableHeaderRenderer,
 }) => (
   <>
     <ExtendedView
@@ -62,14 +63,27 @@ const TableView = ({
       customTheme={themeConfig.tblContainer || {}}
     >
       <Table>
-        <TableHeader
-          customTheme={themeConfig.tblHeader}
-          table={table}
-          rows={tableRows}
-          count={totalRowCount}
-          toggleSelectAll={onToggleSelectAll}
-          sortByColumn={onSortByColumn}
-        />
+        {
+          TableHeaderRenderer ? (
+            <TableHeaderRenderer
+              customTheme={themeConfig.tblHeader}
+              table={table}
+              rows={tableRows}
+              count={totalRowCount}
+              toggleSelectAll={onToggleSelectAll}
+              sortByColumn={onSortByColumn}
+            />
+          ) : (
+            <TableHeader
+              customTheme={themeConfig.tblHeader}
+              table={table}
+              rows={tableRows}
+              count={totalRowCount}
+              toggleSelectAll={onToggleSelectAll}
+              sortByColumn={onSortByColumn}
+            />
+          )
+        }
         <CustomTableBody
           customTheme={themeConfig.tblBody}
           rows={tableRows}

--- a/packages/table/src/index.js
+++ b/packages/table/src/index.js
@@ -4,5 +4,6 @@ export {
   headerTypes,
   ComponentTypes,
   dataFormatTypes,
+  actionCellTypes,
 } from './util/Types';
 export { formatBytes } from './util/Dataformat';


### PR DESCRIPTION
## Description

In this PR, a new prop called `customTableHeader` is added to the `paginated-table` and `table` packages, allowing users to pass a custom table header instead of using the default `TableHeader` component.


Fixes # ([CTDC-1548](https://tracker.nci.nih.gov/browse/CTDC-1548))

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## How Has This Been Tested?
I have tested this on my local and CTDC project.