### PR TITLE
Removed chance for duplicate in local find ID find

### DIFF
--- a/packages/bento-frontend/src/pages/dashTemplate/sideBar/BentoFacetFilter.js
+++ b/packages/bento-frontend/src/pages/dashTemplate/sideBar/BentoFacetFilter.js
@@ -79,6 +79,12 @@ const { UploadModal } = UploadModalGenerator({
 
         // Combine the results and remove duplicates
         const unmatched = new Set(inputArray);
+        //If there are any that weren't originally in inputArray, delete it from matched
+        matched.forEach((obj) => {
+          if (!inputArray.includes(obj.subject_id)) {
+            matched.splice(matched.indexOf(obj), 1);
+          }
+        });
         matched.forEach((obj) => unmatched.delete(obj.subject_id));
         return { matched, unmatched: [...unmatched] };
       } catch (e) {

--- a/packages/bento-frontend/src/pages/dashTemplate/sideBar/BentoFacetFilter.js
+++ b/packages/bento-frontend/src/pages/dashTemplate/sideBar/BentoFacetFilter.js
@@ -72,7 +72,7 @@ const { UploadModal } = UploadModalGenerator({
       try {
         // Split the search terms into chunks of 500
         const caseChunks = chunkSplit(inputArray, 500);
-        const matched = (await Promise.allSettled(caseChunks.map((chunk) => getAllSubjectIds(chunk))))
+        let matched = (await Promise.allSettled(caseChunks.map((chunk) => getAllSubjectIds(chunk))))
           .filter((result) => result.status === 'fulfilled')
           .map((result) => result.value || [])
           .flat(1);
@@ -80,11 +80,7 @@ const { UploadModal } = UploadModalGenerator({
         // Combine the results and remove duplicates
         const unmatched = new Set(inputArray);
         //If there are any that weren't originally in inputArray, delete it from matched
-        matched.forEach((obj) => {
-          if (!inputArray.includes(obj.subject_id)) {
-            matched.splice(matched.indexOf(obj), 1);
-          }
-        });
+        matched = matched.filter((obj) => inputArray.includes(obj.subject_id));
         matched.forEach((obj) => unmatched.delete(obj.subject_id));
         return { matched, unmatched: [...unmatched] };
       } catch (e) {


### PR DESCRIPTION
## Description

There was an issue where an ID would be marked in the found and not found columns even when it was surrounded by asterisks. We want to resolve this issue by only finding perfect matches so if there is one found, it will now be ignored (since it didn't match the input)

Fixes # (issue)
[BENTO-2468](https://tracker.nci.nih.gov/browse/BENTO-2468)
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Locally