### PR TITLE
graphQL will now have variables will handle as empty instead of null

### DIFF
--- a/packages/bento-frontend/src/components/GraphqlClient/GraphqlView.js
+++ b/packages/bento-frontend/src/components/GraphqlClient/GraphqlView.js
@@ -10,7 +10,7 @@ function graphQLFetcher(graphQLParams) {
   return fetch(BACKEND, {
     method: 'post',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(graphQLParams),
+    body: JSON.stringify({...graphQLParams, variables: graphQLParams.variables ?? {}}),
   }).then((response) => response.json());
 }
 


### PR DESCRIPTION
## Description

There was an issue with GraphQL responses not returning the proper value. From the ticket, the query was formatted incorrectly. But aside from the incorrect formatting, the variable's field always needed to be filled out, an easy oversight. I've made the query check to see if variables is null or not, if it is it will default to an empty object, so we avoid the null error. 

Fixes # (issue)
[BENTO-2611](https://tracker.nci.nih.gov/browse/BENTO-2611) 
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Locally 