### PR TITLE
alert message added for 'add selected files' buttons

### DIFF
--- a/packages/bento-frontend/src/pages/dashTemplate/tabs/wrapperConfig/Wrapper.js
+++ b/packages/bento-frontend/src/pages/dashTemplate/tabs/wrapperConfig/Wrapper.js
@@ -41,6 +41,7 @@ export const wrapperConfig = [{
       btnType: btnTypes.ADD_SELECTED_FILES,
       tooltipCofig: tooltipContent,
       conditional: true,
+      alertMessage,
     }],
 },
 {
@@ -60,6 +61,7 @@ export const wrapperConfig = [{
       btnType: btnTypes.ADD_SELECTED_FILES,
       tooltipCofig: tooltipContent,
       conditional: true,
+      alertMessage,
     }],
 },
 {


### PR DESCRIPTION
## Description

Missing config for the alert message caused missing text in pop-up. This is resolved by filling it in. Notable that we need to populate the text in both the top and bottom pagination. 

Fixes # (issue)
[BENTO-2575](https://tracker.nci.nih.gov/browse/BENTO-2575)


Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?