### PR TITLE
Add configurable queryURL length limitation

### DIFF
--- a/packages/query-bar/package.json
+++ b/packages/query-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bento-core/query-bar",
-  "version": "1.0.0-c3dc.4",
+  "version": "1.0.0-c3dc.5",
   "description": "This package provides the Query Bar component that displays the current Facet Search and Local Find filters on the Dashboard/Explore page. It also provides the direct ability to reset all or some of the filters with the click of a button. It is designed to be implemented directly with the:",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/query-bar/src/components/QueryUrl.js
+++ b/packages/query-bar/src/components/QueryUrl.js
@@ -17,6 +17,7 @@ const QueryUrl = ({
   filterItems,
   localFind = {},
   rootPath,
+  queryUrlCharacterLimit = 70,
 }) => {
   const [display, setDisplay] = useState(false);
   const toggleDisplay = () => setDisplay((prevDisplay) => !prevDisplay);
@@ -59,7 +60,7 @@ const QueryUrl = ({
                 type="button"
                 className={clsx(classes.viewLink)}
               >
-                {url}
+                {url.length > queryUrlCharacterLimit ? `${url.substring(0, queryUrlCharacterLimit)}...` : url}
               </div>
               <Tooltip
                 arrow

--- a/packages/query-bar/src/generators/QueryBarGenerator.js
+++ b/packages/query-bar/src/generators/QueryBarGenerator.js
@@ -29,6 +29,10 @@ export const QueryBarGenerator = (uiConfig = DEFAULT_CONFIG) => {
     ? config.viewQueryURL
     : DEFAULT_CONFIG.config.viewQueryURL;
 
+  const queryUrlCharacterLimit = config && typeof config.queryUrlCharacterLimit === 'number'
+    ? config.queryUrlCharacterLimit
+    : DEFAULT_CONFIG.config.queryUrlCharacterLimit;
+
   const clearAll = functions && typeof functions.clearAll === 'function'
     ? functions.clearAll
     : DEFAULT_CONFIG.functions.clearAll;
@@ -195,6 +199,7 @@ export const QueryBarGenerator = (uiConfig = DEFAULT_CONFIG) => {
                 localFind={localFind}
                 filterItems={mappedInputs}
                 rootPath={queryURLRootPath}
+                queryUrlCharacterLimit={queryUrlCharacterLimit}
               />
             )
           }

--- a/packages/query-bar/src/generators/config.js
+++ b/packages/query-bar/src/generators/config.js
@@ -19,6 +19,11 @@ export default {
    * @var {boolean}
    */
   viewQueryURL: false,
+  /**
+   * display copy url button
+   * @var {boolean}
+   */
+  queryUrlCharacterLimit: 70,
 
   /* Component Helper Functions */
   functions: {


### PR DESCRIPTION
## Description

Add in a configurable length to adjust for the length of the string before displaying an elipsis

Fixes # (issue)
[C3DC-1467](https://tracker.nci.nih.gov/browse/C3DC-1467)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?
Locally