### PR TITLE
CDS-1258/1265  external URLs now open within the same tab + email support

### DIFF
--- a/packages/footer/src/FooterController.js
+++ b/packages/footer/src/FooterController.js
@@ -8,15 +8,26 @@ const FooterController = ({ data = {} }) => {
   const tablet = useMediaQuery('(min-width: 768px) and (max-width: 1024px)');
   const mobile = useMediaQuery('(max-width: 767px)');
 
+  let externalTab = null;
+  function handleExternalLinkClick(e, url) {
+    e.preventDefault();
+    if (!externalTab || externalTab.closed) {
+      externalTab = window.open(url, 'footerExternalURL');
+    } else {
+      externalTab.location.href = url;
+      externalTab.focus();
+    }
+  }
+
   if (mobile) {
-    return <FooterMobile data={data} />;
+    return <FooterMobile data={data} handleExternalLinkClick={handleExternalLinkClick} />;
   }
 
   if (tablet) {
-    return <FooterTablet data={data} />;
+    return <FooterTablet data={data} handleExternalLinkClick={handleExternalLinkClick} />;
   }
 
-  return <FooterDesktop data={data} />;
+  return <FooterDesktop data={data} handleExternalLinkClick={handleExternalLinkClick} />;
 };
 
 export default FooterController;

--- a/packages/footer/src/FooterDesktop.js
+++ b/packages/footer/src/FooterDesktop.js
@@ -1,5 +1,4 @@
 import React, { useState, useRef } from 'react';
-import { Link } from 'react-router-dom';
 import { withStyles } from '@material-ui/core';
 
 const styles = () => ({
@@ -255,9 +254,9 @@ const FooterDesktop = ({ classes, data, handleExternalLinkClick }) => {
                           {item.text}
                         </a>
                       ) : (
-                        <Link className={classes.footItemLink} to={item.link}>
+                        <a className={classes.footItemLink} href={item.link}>
                           {item.text}
-                        </Link>
+                        </a>
                       )}
                     </div>
                   );

--- a/packages/footer/src/FooterDesktop.js
+++ b/packages/footer/src/FooterDesktop.js
@@ -202,7 +202,7 @@ const styles = () => ({
   },
 });
 
-const FooterDesktop = ({ classes, data }) => {
+const FooterDesktop = ({ classes, data, handleExternalLinkClick }) => {
   const [emailContent, setEmailContent] = useState('');
   const emailForm = useRef(null);
   const emailInput = useRef(null);
@@ -249,7 +249,7 @@ const FooterDesktop = ({ classes, data }) => {
                         <a
                           className={classes.footItemLink}
                           href={item.link}
-                          target="_blank"
+                          onClick={(e) => handleExternalLinkClick(e, item.link)}
                           rel="noopener noreferrer"
                         >
                           {item.text}

--- a/packages/footer/src/FooterMobile.js
+++ b/packages/footer/src/FooterMobile.js
@@ -1,5 +1,4 @@
 import React, { useState, useRef } from 'react';
-import { Link } from 'react-router-dom';
 import { withStyles } from '@material-ui/core';
 
 const styles = () => ({
@@ -332,13 +331,13 @@ const FooterMobile = ({ classes, data, handleExternalLinkClick }) => {
                           {item.text}
                         </a>
                       ) : (
-                        <Link
+                        <a
                           className="footItemLink"
                           key={itemKey}
-                          to={item.link}
+                          href={item.link}
                         >
                           {item.text}
-                        </Link>
+                        </a>
                       );
                     })}
                   </div>

--- a/packages/footer/src/FooterMobile.js
+++ b/packages/footer/src/FooterMobile.js
@@ -248,7 +248,7 @@ const styles = () => ({
   },
 });
 
-const FooterMobile = ({ classes, data }) => {
+const FooterMobile = ({ classes, data, handleExternalLinkClick }) => {
   const [emailContent, setEmailContent] = useState('');
   const emailForm = useRef(null);
   const emailInput = useRef(null);
@@ -326,7 +326,7 @@ const FooterMobile = ({ classes, data }) => {
                           className="footItemLink"
                           key={itemKey}
                           href={item.link}
-                          target="_blank"
+                          onClick={(e) => handleExternalLinkClick(e, item.link)}
                           rel="noopener noreferrer"
                         >
                           {item.text}

--- a/packages/footer/src/FooterTablet.js
+++ b/packages/footer/src/FooterTablet.js
@@ -209,7 +209,7 @@ const styles = () => ({
   },
 });
 
-const FooterTablet = ({ classes, data }) => {
+const FooterTablet = ({ classes, data, handleExternalLinkClick }) => {
   const [emailContent, setEmailContent] = useState('');
   const emailForm = useRef(null);
   const emailInput = useRef(null);
@@ -259,7 +259,7 @@ const FooterTablet = ({ classes, data }) => {
                         <a
                           className="footItemLink"
                           href={item.link}
-                          target="_blank"
+                          onClick={(e) => handleExternalLinkClick(e, item.link)}
                           rel="noopener noreferrer"
                         >
                           {item.text}

--- a/packages/footer/src/FooterTablet.js
+++ b/packages/footer/src/FooterTablet.js
@@ -1,5 +1,4 @@
 import React, { useState, useRef } from 'react';
-import { Link } from 'react-router-dom';
 import { withStyles } from '@material-ui/core';
 
 const styles = () => ({
@@ -265,9 +264,9 @@ const FooterTablet = ({ classes, data, handleExternalLinkClick }) => {
                           {item.text}
                         </a>
                       ) : (
-                        <Link className="footItemLink" to={item.link}>
+                        <a className="footItemLink" href={item.link}>
                           {item.text}
-                        </Link>
+                        </a>
                       )}
                     </div>
                   );


### PR DESCRIPTION
## Description

If you go to the old [CDS](https://dataservice.datacommons.cancer.gov/#/data) page using the old footer. You'll notice that the footer links under the "more information" section open into the same tab, overriding each other if more than one are opened. This functionality was lost with the introduction of the new footer.

Fixes # (issue)
[CDS-1258](https://tracker.nci.nih.gov/browse/CDS-1258)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Locally