### PR TITLE
CDS-1261 Bug: Fix pagination options wrapping

### DIFF
--- a/packages/global-search/src/SearchResults/components/PaginatedPanel.js
+++ b/packages/global-search/src/SearchResults/components/PaginatedPanel.js
@@ -180,13 +180,13 @@ const PaginatedPanel = (props) => {
 
 const styles = {
   prevButton: {
-    marginRight: '44px',
+    marginRight: 0,
     fontFamily: '"Open Sans", sans-serif',
     fontWeight: 'bold',
     fontSize: '12px',
   },
   nextButton: {
-    marginLeft: '44px',
+    marginLeft: 0,
     fontFamily: '"Open Sans", sans-serif',
     fontWeight: 'bold',
     fontSize: '12px',
@@ -201,7 +201,7 @@ const styles = {
   },
   paginationContainer: {
     display: 'flex',
-    justifyContent: 'center',
+    justifyContent: 'space-between',
     maxWidth: '680px',
     margin: '0 auto',
     paddingBottom: '20px',


### PR DESCRIPTION
## Description

Fix pagination options wrapping on to a new line. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tested manually on CDS local.