### PR TITLE
CDS-1260 Bug: Fix global search popper appearing under footer

### DIFF
--- a/packages/global-search/src/SearchBar/components/CustomPopper.js
+++ b/packages/global-search/src/SearchBar/components/CustomPopper.js
@@ -10,11 +10,13 @@ import { Popper } from '@material-ui/core';
 export const CustomPopper = (props) => {
   const {
     classes,
+    style,
   } = props;
 
   return (
     <Popper
       {...props}
+      style={{ ...style, zIndex: 1502 }}
       className={classes.root}
       placement="bottom"
     />


### PR DESCRIPTION
## Description

The dropdown popper from the global search page was appearing under the footer. Updated the zIndex to fix this.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tested manually on CDS local.