### PR TITLE
added conditional to trigger dispatch for non-explore pages

### DIFF
--- a/packages/paginated-table/package.json
+++ b/packages/paginated-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bento-core/paginated-table",
-  "version": "1.0.0-c3dc.29",
+  "version": "1.0.0-c3dc.30",
   "main": "dist/index.js",
   "scripts": {
     "build": "npm run lint && cross-env-shell rm -rf dist && NODE_ENV=production BABEL_ENV=es babel src --out-dir dist --copy-files",

--- a/packages/paginated-table/src/table/PaginatedTable.js
+++ b/packages/paginated-table/src/table/PaginatedTable.js
@@ -32,7 +32,9 @@ const PaginatedTable = ({
   */
   const [table, dispatch] = useReducer(reducer, {}, initState);
   useEffect(() => {
-    dispatch(unselectAllRows());
+    if (Object.keys(queryVariables).length > 0) {
+      dispatch(unselectAllRows());
+    }
   }, [queryVariables]);
 
   /**


### PR DESCRIPTION
## Description

The studies page kept triggering the refresh button putting it in a loop and essentially freezing the page. Adding this conditional prevents it. Also as a side note this does not hinder the clear-all functionality on the explore page because the query variables on the explore page always includes the participant ID array, even if it's empty.

Fixes # (issue)
[C3DC-1516](https://tracker.nci.nih.gov/browse/C3DC-1516)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Locally