### PR TITLE
Update format for slider facets to avoid crashing

### DIFF
--- a/packages/bento-frontend/src/pages/dashTemplate/sideBar/BentoFilterUtils.js
+++ b/packages/bento-frontend/src/pages/dashTemplate/sideBar/BentoFilterUtils.js
@@ -1,6 +1,7 @@
 
 import {
-  clearAllAndSelectFacet
+  clearAllAndSelectFacet,
+  InputTypes,
  } from '@bento-core/facet-filter';
 
 import {
@@ -13,6 +14,7 @@ import {
 } from '../../../bento/localSearchData';
 import store from '../../../store';
 import client from '../../../utils/graphqlClient';
+import { facetsConfig } from '../../../bento/dashTemplate';
 
 export const getFacetValues = (facet, facetValue) => ({[facet]: { [facetValue]: true }});
 
@@ -79,7 +81,20 @@ export const setActiveFilterByPathQuery = (match) => {
     }
     return curr;
   }, {});
-  store.dispatch(clearAllAndSelectFacet(activeFilterValues));
+  
+  const transformSliderFilters = (filters) => {
+    return Object.keys(filters).reduce((acc, key) => {
+      const isSlider = facetsConfig.some(facet => facet.datafield === key && facet.type === InputTypes.SLIDER);
+      if (isSlider) {
+        acc[key] = Object.keys(filters[key]).map(Number);
+      } else {
+        acc[key] = filters[key]; 
+      }
+      return acc;
+    }, {});
+  };
+
+  store.dispatch(clearAllAndSelectFacet(transformSliderFilters(activeFilterValues)));
   store.dispatch(updateAutocompleteData(autocomplete));
   store.dispatch(updateUploadData(upload));
   store.dispatch(updateUploadMetadata(uploadMetadata));


### PR DESCRIPTION
## Description

The setActiveFilterByPathQuery function does not accomodate for sliders since it was designed with sliders in mind. This oversight formats entries for the sliders incorrectly and will cause the site to crash on generating a link that contains a facet. 

This is because when it tries to set the slider filters from the query, it will cause an issue at this line https://github.com/CBIIT/bento-frontend/blob/0f4eb823125d4923526b1e10f0526adf84e1d413/packages/facet-filter/src/components/facet/FacetView.js#L90. 

Sliders should be an array of two numbers, the min and max, but the current format sets it as an object with the {min: true, max: true}.

Fixes # (issue)
[BENTO-2653](https://tracker.nci.nih.gov/browse/BENTO-2653) 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Locally