### PR TITLE
clear all also clears text search inputs

### DIFF
--- a/packages/facet-filter/package.json
+++ b/packages/facet-filter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bento-core/facet-filter",
-  "version": "1.0.1-c3dc.5",
+  "version": "1.0.1-c3dc.6",
   "description": "### Bento core sidebar design:",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/facet-filter/src/store/reducers/SideBarReducer.js
+++ b/packages/facet-filter/src/store/reducers/SideBarReducer.js
@@ -101,6 +101,7 @@ export function sideBarReducerGenerator() {
           return {
             ...state,
             filterState: {},
+            searchState: {},
           };
         case sideBarActionTypes.CLEAR_FACET_SECTION:
           updateState = onClearFacetSection({ ...payload, ...state });


### PR DESCRIPTION
## Description

The clear all button now also clears the inputs from the text search features within the facet

Fixes # (issue)
[C3DC-1522](https://tracker.nci.nih.gov/browse/C3DC-1522)

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Locally