### PR TITLE
C3DC 1349

### DIFF
--- a/packages/local-find/package.json
+++ b/packages/local-find/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bento-core/local-find",
-  "version": "1.0.0-c3dc.2",
+  "version": "1.0.0-c3dc.3",
   "description": "The Local Find package provides components relating to the Dashboard/Explore case search feature. There are two primary components provided by this package:",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/local-find/src/SearchBox/SearchBoxGenerator.js
+++ b/packages/local-find/src/SearchBox/SearchBoxGenerator.js
@@ -152,12 +152,21 @@ export const SearchBoxGenerator = (uiConfig = DEFAULT_CONFIG) => {
               getOptionLabel={(option) => option.title}
               renderTags={() => null}
               renderOption={(option) => {
-                const { type, title } = option;
+                const { type, title, synonym } = option;
                 return (
                   <>
-                    {type === 'associatedIds' && (<span className={classes.filterName}>Synonym</span>)}
                     <div style={{ }}>
-                      {title}
+                      {type === 'associatedIds' ? (
+                        <>
+                          <span className={classes.filterName}>Synonym</span>
+                          {' '}
+                          { synonym }
+                        </>
+                      ) : (
+                        <>
+                          { title }
+                        </>
+                      )}
                     </div>
                   </>
                 );

--- a/packages/local-find/src/SearchBox/SearchBoxGenerator.js
+++ b/packages/local-find/src/SearchBox/SearchBoxGenerator.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { connect } from 'react-redux';
 import { withStyles } from '@material-ui/core';
-import Autocomplete, { createFilterOptions } from '@material-ui/lab/Autocomplete';
+import Autocomplete from '@material-ui/lab/Autocomplete';
 import { isEqual } from 'lodash';
 import TextField from './components/CustomTextField';
 import SearchList from './components/SearchList';
@@ -141,7 +141,13 @@ export const SearchBoxGenerator = (uiConfig = DEFAULT_CONFIG) => {
               noOptionsText={noOptionsText}
               options={options}
               loading={loading}
-              filterOptions={createFilterOptions({ trim: true })}
+              filterOptions={(filterOptions, { inputValue }) => filterOptions.filter((option) => {
+                const titleMatch = option.title?.toLowerCase().includes(inputValue.toLowerCase());
+                const synonymMatch = option.synonym?.toString().toLowerCase().includes(
+                  inputValue.toLowerCase(),
+                );
+                return titleMatch || synonymMatch;
+              })}
               onOpen={() => {
                 setOpen(true);
               }}

--- a/packages/local-find/src/SearchBox/SearchBoxGenerator.js
+++ b/packages/local-find/src/SearchBox/SearchBoxGenerator.js
@@ -37,7 +37,7 @@ export const SearchBoxGenerator = (uiConfig = DEFAULT_CONFIG) => {
     ? config.noOptionsText
     : DEFAULT_CONFIG.config.noOptionsText;
 
-  const searchType = config && typeof config.searchType === 'string'
+  const searchType = config && typeof config.searchType === 'object'
     ? config.searchType
     : DEFAULT_CONFIG.config.searchType;
 
@@ -124,7 +124,7 @@ export const SearchBoxGenerator = (uiConfig = DEFAULT_CONFIG) => {
           <div>
             <SearchList
               classes={classes}
-              items={value.map((e) => e.title)}
+              items={value}
               onDelete={onDelete}
             />
           </div>
@@ -151,6 +151,17 @@ export const SearchBoxGenerator = (uiConfig = DEFAULT_CONFIG) => {
               onChange={(event, newValue, reason) => onChangeWrapper(newValue, reason)}
               getOptionLabel={(option) => option.title}
               renderTags={() => null}
+              renderOption={(option) => {
+                const { type, title } = option;
+                return (
+                  <>
+                    {type === 'associatedIds' && (<span className={classes.filterName}>Synonym</span>)}
+                    <div style={{ }}>
+                      {title}
+                    </div>
+                  </>
+                );
+              }}
               renderInput={(params) => (
                 <TextField
                   {...params}

--- a/packages/local-find/src/SearchBox/components/SearchList.js
+++ b/packages/local-find/src/SearchBox/components/SearchList.js
@@ -34,11 +34,12 @@ const SearchList = (props) => {
           <Divider className={classes.divider} />
           <ListItem classes={{ gutters: classes.listItemGutters }} key={index}>
             <div className={classes.searchResultDetailText}>
+              {item.type === 'associatedIds' && (<span className={classes.filterName}>Synonym</span>)}
               <span>
-                {item}
+                {item.title}
               </span>
             </div>
-            <div className={classes.deleteIcon} onClick={() => deleteWrapper(item)}>
+            <div className={classes.deleteIcon} onClick={() => deleteWrapper(item.title)}>
               <img src="https://raw.githubusercontent.com/CBIIT/datacommons-assets/main/bento/images/icons/svgs/LocalFindCaseDeleteIcon.svg" alt="close icon" className={classes.closeRoot} />
             </div>
           </ListItem>

--- a/packages/local-find/src/SearchBox/components/SearchList.js
+++ b/packages/local-find/src/SearchBox/components/SearchList.js
@@ -34,10 +34,18 @@ const SearchList = (props) => {
           <Divider className={classes.divider} />
           <ListItem classes={{ gutters: classes.listItemGutters }} key={index}>
             <div className={classes.searchResultDetailText}>
-              {item.type === 'associatedIds' && (<span className={classes.filterName}>Synonym</span>)}
-              <span>
-                {item.title}
-              </span>
+              {(item.type === 'associatedIds' ? (
+                <>
+                  <span className={classes.filterName}>Synonym</span>
+                  <span>
+                    {item.synonym}
+                  </span>
+                </>
+              ) : (
+                <span>
+                  {item.title}
+                </span>
+              ))}
             </div>
             <div className={classes.deleteIcon} onClick={() => deleteWrapper(item.title)}>
               <img src="https://raw.githubusercontent.com/CBIIT/datacommons-assets/main/bento/images/icons/svgs/LocalFindCaseDeleteIcon.svg" alt="close icon" className={classes.closeRoot} />

--- a/packages/local-find/src/SearchBox/config.js
+++ b/packages/local-find/src/SearchBox/config.js
@@ -7,7 +7,7 @@ export const DEFAULT_CONFIG_SEARCHBAR = {
   config: {
     inputPlaceholder: 'e.g. BENTO-CASE-06, BENTO-CASE-22',
     noOptionsText: 'No matching items found',
-    searchType: 'subjectIds',
+    searchType: ['subjectIds'],
     ariaLabel: 'Search',
   },
 

--- a/packages/local-find/src/SearchBox/styles.js
+++ b/packages/local-find/src/SearchBox/styles.js
@@ -73,4 +73,16 @@ export default () => ({
   searchBoxRoot: {
     width: '100%',
   },
+  filterName: {
+    cursor: 'pointer',
+    padding: '0px 2px 0px 2px',
+    fontSize: '10px',
+    fontWeight: 600,
+    borderRadius: '4px',
+    textTransform: 'uppercase',
+    color: '#000',
+    backgroundColor: '#F6A700',
+    marginRight: '4px',
+
+  },
 });

--- a/packages/local-find/src/SearchView.js
+++ b/packages/local-find/src/SearchView.js
@@ -54,7 +54,7 @@ const SearchView = (props) => {
       {matchedFiles.length !== 0 ? (
         <SearchList
           classes={{ divider: classes.customDivider, listPadding: classes.customListPadding }}
-          items={['INPUT SET']}
+          items={[{ title: 'INPUT SET' }]}
           id="localFindCaseUploadSet"
           onDelete={resetUpload}
         />

--- a/packages/query-bar/package.json
+++ b/packages/query-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bento-core/query-bar",
-  "version": "1.0.0-c3dc.6",
+  "version": "1.0.0-c3dc.7",
   "description": "This package provides the Query Bar component that displays the current Facet Search and Local Find filters on the Dashboard/Explore page. It also provides the direct ability to reset all or some of the filters with the click of a button. It is designed to be implemented directly with the:",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/query-bar/src/generators/QueryBarGenerator.js
+++ b/packages/query-bar/src/generators/QueryBarGenerator.js
@@ -204,7 +204,7 @@ export const QueryBarGenerator = (uiConfig = DEFAULT_CONFIG) => {
                           }
                           onClick={() => deleteAutocompleteItem(d.title)}
                         >
-                          {d.title}
+                          {d.synonym}
                         </span>
                         {idx < arr.length - 1 && ' '}
                       </React.Fragment>

--- a/packages/query-bar/src/generators/QueryBarGenerator.js
+++ b/packages/query-bar/src/generators/QueryBarGenerator.js
@@ -107,70 +107,117 @@ export const QueryBarGenerator = (uiConfig = DEFAULT_CONFIG) => {
           <span className={classes.queryContainer}>
             {/* Local Find Selections */}
             {/* TODO: Refactor this into a separate component */}
-            {(autocomplete.length || upload.length) ? (
-              <span>
-                {/* Standalone case set button */}
-                {(upload.length && !autocomplete.length)
-                  ? (
+            {/* Section: Localfind Results */}
+            {(autocomplete.length || upload.length) > 0 && (
+            <span>
+              {/* Participant ID Section */}
+              {(() => {
+                const participantItems = autocomplete.filter((i) => i.type === 'participantIds');
+                const participantCount = upload.length + participantItems.length;
+
+                if (upload.length > 0 && participantItems.length === 0) {
+                  // Only upload, no participant autocomplete
+                  return (
                     <span
                       className={clsx(classes.filterCheckboxes, classes.localFindBackground)}
                       onClick={clearUpload}
                     >
                       INPUT PARTICIPANT SET
                     </span>
-                  ) : null}
-                {autocomplete.length
-                  ? (
-                    <span>
-                      {' '}
+                  );
+                }
+
+                if (participantCount > 0) {
+                  const operator = participantCount === 1 ? 'IS' : 'IN';
+
+                  return (
+                    <>
                       <span
                         className={clsx(classes.filterName, classes.localFindBackground)}
                         onClick={clearAutocomplete}
                       >
                         Participant ID
                       </span>
-                      {' '}
-                      {' '}
-                      <span className={classes.operators}>
-                        {(autocomplete.length === 1 && !upload.length) ? 'IS ' : 'IN '}
-                      </span>
+                      <span className={classes.operators}>{operator}</span>
+
+                      {operator === 'IN' && <span className={classes.bracketsOpen}>(</span>}
+
+                      {upload.length > 0 && (
+                      <>
+                        <span
+                          className={clsx(classes.filterCheckboxes, classes.localFind)}
+                          onClick={clearUpload}
+                        >
+                          INPUT PARTICIPANT SET
+                        </span>
+                      </>
+                      )}
+
+                      {participantItems.slice(0, maxItems).map((d, idx, arr) => (
+                        <React.Fragment key={`pid-${idx}`}>
+                          <span
+                            className={clsx(classes.filterCheckboxes, classes.facetSectionCases)}
+                            onClick={() => deleteAutocompleteItem(d.title)}
+                          >
+                            {d.title}
+                          </span>
+                          {idx < arr.length - 1 && ' '}
+                        </React.Fragment>
+                      ))}
+                      {participantItems.length > maxItems && '...'}
+                      {operator === 'IN' && <span className={classes.bracketsClose}>)</span>}
+                    </>
+                  );
+                }
+
+                return null;
+              })()}
+
+              {/* 'or' logic */}
+              {(upload.length > 0 || autocomplete.some((i) => i.type === 'participantIds'))
+              && autocomplete.some((i) => i.type === 'associatedIds')
+              && (<span className={classes.operators}>OR</span>)}
+
+              {/* Associated ID Section */}
+              {(() => {
+                const associatedItems = autocomplete.filter((i) => i.type === 'associatedIds');
+                if (associatedItems.length === 0) return null;
+
+                const operator = associatedItems.length === 1 ? 'IS' : 'IN';
+
+                return (
+                  <>
+                    <span
+                      className={clsx(classes.filterName, classes.localFindAssociatedIdsBackground)}
+                      onClick={clearAutocomplete}
+                    >
+                      Synonym
                     </span>
-                  ) : null}
-                <span>
-                  {(((upload.length > 0 ? 1 : 0) + autocomplete.length) > 1)
-                    ? <span className={classes.bracketsOpen}>(</span>
-                    : null}
-                  {upload.length && autocomplete.length ? (
-                    <>
-                      {' '}
-                      <span
-                        className={clsx(classes.filterCheckboxes, classes.localFind)}
-                        onClick={clearUpload}
-                      >
-                        INPUT PARTICIPANT SET
-                      </span>
-                      {' '}
-                    </>
-                  ) : null}
-                  {autocomplete.slice(0, maxItems).map((d, idx) => (
-                    <>
-                      <span
-                        className={clsx(classes.filterCheckboxes, classes.facetSectionCases)}
-                        key={idx}
-                        onClick={() => deleteAutocompleteItem(d.title)}
-                      >
-                        {d.title}
-                      </span>
-                      {idx === (maxItems - 1) ? null : ' '}
-                    </>
-                  ))}
-                  {autocomplete.length > maxItems && '...'}
-                  {(((upload.length > 0 ? 1 : 0) + autocomplete.length) > 1)
-                    ? <span className={classes.bracketsClose}>)</span>
-                    : null}
-                </span>
-              </span>
-            ) : null}
+                    <span className={classes.operators}>{operator}</span>
+                    {operator === 'IN' && <span className={classes.bracketsOpen}>(</span>}
+
+                    {associatedItems.slice(0, maxItems).map((d, idx, arr) => (
+                      <React.Fragment key={`aid-${idx}`}>
+                        <span
+                          className={
+                            clsx(classes.filterCheckboxes, classes.localFindAssociatedIdsText)
+                          }
+                          onClick={() => deleteAutocompleteItem(d.title)}
+                        >
+                          {d.title}
+                        </span>
+                        {idx < arr.length - 1 && ' '}
+                      </React.Fragment>
+                    ))}
+                    {associatedItems.length > maxItems && '...'}
+                    {operator === 'IN' && <span className={classes.bracketsClose}>)</span>}
+                  </>
+                );
+              })()}
+            </span>
+            )}
+
+            {/* --------------------- */}
 
             {/* Facet Sidebar Selections */}
             {((autocomplete.length || upload.length) && mappedInputs.length)

--- a/packages/query-bar/src/generators/styles.js
+++ b/packages/query-bar/src/generators/styles.js
@@ -147,4 +147,10 @@ export default () => ({
     backgroundColor: '#DDEAE540',
     border: '1px solid #646464',
   },
+  localFindAssociatedIdsBackground: {
+    backgroundColor: '#F6A700',
+  },
+  localFindAssociatedIdsText: {
+    color: '#B36B00',
+  },
 });


### PR DESCRIPTION
## Description

### Summary of the Change

This update enhances the Local Find functionality across multiple packages by introducing support for multiple `searchType` values and differentiating behavior based on item `type` (e.g., `participantIds` vs `associatedIds`). It also updates the rendering logic in the UI to handle structured item objects instead of raw strings.

### Key Fixes / Features

- Changes `searchType` in config from a `string` to an `array` to allow multiple types.
- Modifies the Autocomplete logic to handle `searchType` as an array.
- Updates `SearchBoxGenerator` and `SearchList` to support and render structured item types.
- Adds conditional rendering for associated ID types with distinct UI (e.g., “Synonym” tag).
- Enhances `QueryBarGenerator` logic to:
  - Separate rendering for `participantIds` and `associatedIds`
  - Show `OR` logic where applicable
  - Provide consistent use of `IS` vs `IN` logic with parentheses
- UI style updates with new `.filterName` class for filter labels.
- Version bump in affected packages:
  - `@bento-core/local-find` to `1.0.0-c3dc.3`
  - `@bento-core/query-bar` to `1.0.0-c3dc.7`

### Dependencies

No new external dependencies introduced.

Fixes # [C3DC-1349](https://tracker.nci.nih.gov/browse/C3DC-1349)

---

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] This change requires a documentation update  

---

## How Has This Been Tested?

- Manual testing in the Dashboard/Explore interface using Local Find with both `participantIds` and `associatedIds`.
- Verified that:
  - Autocomplete suggestions render correctly with new UI structure.
  - Deleted items behave as expected (correct keys and values).
  - Upload and manual inputs are combined and represented clearly.
  - Visual elements (tags, filters) behave responsively.
  - Backward compatibility with previous `searchType: 'subjectIds'` fails gracefully, validating this as a breaking change.
