### PR TITLE
added defensive clause to block against rendering a null instance

### DIFF
--- a/packages/tab/package.json
+++ b/packages/tab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bento-core/tab",
-  "version": "1.0.0-c3dc.2",
+  "version": "1.0.0-c3dc.3",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/tab/src/Tabs.js
+++ b/packages/tab/src/Tabs.js
@@ -121,12 +121,18 @@ const TabItems = ({
 
     // Add tabs after visible range
     for (let i = visibleEnd; i < tabItems.length; i += 1) {
-      hiddenTabsWithIndex.push({ tab: tabItems[i], originalIndex: i });
+      const tab = tabItems[i];
+      if (tab) {
+        hiddenTabsWithIndex.push({ tab, originalIndex: i });
+      }
     }
 
     // Add tabs before visible range (wrap-around)
     for (let i = 0; i < visibleStart; i += 1) {
-      hiddenTabsWithIndex.push({ tab: tabItems[i], originalIndex: i });
+      const tab = tabItems[i];
+      if (tab) {
+        hiddenTabsWithIndex.push({ tab, originalIndex: i });
+      }
     }
 
     return hiddenTabsWithIndex;
@@ -257,21 +263,26 @@ const TabItems = ({
             style={{ marginTop: '10px' }}
           >
             <List className="popover-list">
-              {popupTabs.map(({ tab, originalIndex }) => (
-                <ListItem
-                  key={originalIndex}
-                  button
-                  onClick={() => handlePopupTabClick(originalIndex)}
-                  className="popover-list-item"
-                >
-                  <span className="popover-tab-name">
-                    {tab.name}
-                  </span>
-                  <span className="popover-tab-count">
-                    {tab.count || ''}
-                  </span>
-                </ListItem>
-              ))}
+              {popupTabs.map(({ tab, originalIndex }) => {
+                if (!tab || !tab.name) {
+                  return null;
+                }
+                return (
+                  <ListItem
+                    key={originalIndex}
+                    button
+                    onClick={() => handlePopupTabClick(originalIndex)}
+                    className="popover-list-item"
+                  >
+                    <span className="popover-tab-name">
+                      {tab.name}
+                    </span>
+                    <span className="popover-tab-count">
+                      {tab.count || ''}
+                    </span>
+                  </ListItem>
+                );
+              })}
             </List>
           </Popover>
         )}


### PR DESCRIPTION

## Description

 When users were on tab 7 and resized their browser window from a small breakpoint to around 1375px, the application would crash with this error:
  Uncaught TypeError: Cannot read properties of undefined (reading 'name')
  at Tabs.js:383 (in the popup tab rendering)

    - Trying to render undefined.name crashed the app


Fixes # (issue)
instant crashing

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Locally