### PR TITLE
PORTAL-2324: Add customizable pagination options 

### DIFF
--- a/packages/paginated-table/package.json
+++ b/packages/paginated-table/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@bento-core/cart": "1.0.1-ccdihub.9",
-    "@bento-core/table": "1.0.1-ccdihub.105",
+    "@bento-core/table": "1.0.1-ccdihub.107",
     "@bento-core/tool-tip": "^1.0.0",
     "@bento-core/util": "^1.0.0"
   },

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bento-core/table",
-  "version": "1.0.1-ccdihub.106",
+  "version": "1.0.1-ccdihub.107",
   "main": "dist/index.js",
   "scripts": {
     "build": "npm run lint && cross-env-shell rm -rf dist && NODE_ENV=production BABEL_ENV=es babel src --out-dir dist --copy-files",

--- a/packages/table/src/ExtendedView.js
+++ b/packages/table/src/ExtendedView.js
@@ -48,7 +48,7 @@ const ExtendedView = ({
             <div className="downloadArea" style={downloadAreaStyle}>
               <CustomPagination
                 customTheme={customTheme.tblTopPgn}
-                rowsPerPageOptions={[10, 25, 50, 100]}
+                rowsPerPageOptions={table.rowsPerPageOptions || [10, 25, 50, 100]}
                 component="div"
                 count={table.totalRowCount || 0}
                 rowsPerPage={table.rowsPerPage || 10}

--- a/packages/table/src/TableView.js
+++ b/packages/table/src/TableView.js
@@ -152,7 +152,7 @@ const TableView = ({
       <div className="downloadArea" style={getPaginationStyle(table, hasExport)}>
         <CustomPagination
           customTheme={themeConfig.tblPgn}
-          rowsPerPageOptions={[10, 25, 50, 100]}
+          rowsPerPageOptions={table.rowsPerPageOptions || [10, 25, 50, 100]}
           component="div"
           count={table.totalRowCount || 0}
           rowsPerPage={table.rowsPerPage || 10}


### PR DESCRIPTION
This pull request updates the table component to allow customizable pagination options and bumps the table package version in dependent projects. The changes ensure that the `rowsPerPageOptions` can be set dynamically via the `table` prop, improving flexibility for consumers of the table component.

**Pagination customization:**

* Updated both `ExtendedView` and `TableView` components in `packages/table/src/ExtendedView.js` and `packages/table/src/TableView.js` to use `table.rowsPerPageOptions` if provided, defaulting to `[10, 25, 50, 100]` otherwise. [[1]](diffhunk://#diff-9d5e542d3c7b581b6fb21b219c47ffeb783d4e6503e645a4b605785b0a7f619eL51-R51) [[2]](diffhunk://#diff-327b03a953c752d7f7f3f490b0eae89a5c43247e8b685fe463e5258ffb5f62f9L155-R155)

**Version bump and dependency update:**

* Bumped the version of `@bento-core/table` to `1.0.1-ccdihub.107` in `packages/table/package.json`.
* Updated the dependency on `@bento-core/table` to `1.0.1-ccdihub.107` in `packages/paginated-table/package.json`.
