### PR TITLE
PORTAL-2324: Bump @bento-core/table to 1.0.1-ccdihub.108

### DIFF
--- a/packages/paginated-table/package.json
+++ b/packages/paginated-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bento-core/paginated-table",
-  "version": "1.0.1-ccdihub.134",
+  "version": "1.0.1-ccdihub.137",
   "main": "dist/index.js",
   "scripts": {
     "build": "npm run lint && cross-env-shell rm -rf dist && NODE_ENV=production BABEL_ENV=es babel src --out-dir dist --copy-files",

--- a/packages/paginated-table/package.json
+++ b/packages/paginated-table/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@bento-core/cart": "1.0.1-ccdihub.9",
-    "@bento-core/table": "1.0.1-ccdihub.107",
+    "@bento-core/table": "1.0.1-ccdihub.108",
     "@bento-core/tool-tip": "^1.0.0",
     "@bento-core/util": "^1.0.0"
   },

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bento-core/table",
-  "version": "1.0.1-ccdihub.107",
+  "version": "1.0.1-ccdihub.108",
   "main": "dist/index.js",
   "scripts": {
     "build": "npm run lint && cross-env-shell rm -rf dist && NODE_ENV=production BABEL_ENV=es babel src --out-dir dist --copy-files",


### PR DESCRIPTION
This pull request includes a minor version bump for the `@bento-core/table` package across related projects to ensure consistency and access to the latest updates.

* Dependency update:
  * Updated the `@bento-core/table` dependency in `packages/paginated-table/package.json` from version `1.0.1-ccdihub.107` to `1.0.1-ccdihub.108`.
* Package version bump:
  * Bumped the version of `@bento-core/table` in its own `package.json` from `1.0.1-ccdihub.107` to `1.0.1-ccdihub.108`.