### PR TITLE
C3DC-1888, Allow for chunked table downloads

### DIFF
--- a/packages/paginated-table/package.json
+++ b/packages/paginated-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bento-core/paginated-table",
-  "version": "1.0.0-c3dc.35",
+  "version": "1.0.0-c3dc.36",
   "main": "dist/index.js",
   "scripts": {
     "build": "npm run lint && cross-env-shell rm -rf dist && NODE_ENV=production BABEL_ENV=es babel src --out-dir dist --copy-files",

--- a/packages/paginated-table/package.json
+++ b/packages/paginated-table/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@bento-core/cart": "1.0.1-ccdihub.7",
-    "@bento-core/table": "^1.0.0-c3dc.29",
+    "@bento-core/table": "^1.0.0-c3dc.30",
     "@bento-core/tool-tip": "^1.0.0",
     "@bento-core/util": "^1.0.0"
   },

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bento-core/table",
-  "version": "1.0.0-c3dc.29",
+  "version": "1.0.0-c3dc.30",
   "main": "dist/index.js",
   "scripts": {
     "build": "cross-env-shell rm -rf dist && NODE_ENV=production BABEL_ENV=es babel src --out-dir dist --copy-files",

--- a/packages/table/src/toolbar/DownloadButtonView.js
+++ b/packages/table/src/toolbar/DownloadButtonView.js
@@ -48,7 +48,7 @@ const DownloadButton = ({
   }
 
   const client = useApolloClient();
-  const downloadLimit = buttonConfig?.downloadLimit || 5000;
+  const downloadLimit = buttonConfig?.downloadLimit;
 
   function cleanData(result) {
     function hasHTMLTags(str) {
@@ -90,7 +90,7 @@ const DownloadButton = ({
       const queryResponse = data[statsQueryName];
       return {
         totalCount: queryResponse[statsField],
-        pageSize: downloadLimit ?? queryResponse.pageSize,
+        pageSize: downloadLimit || queryResponse.pageSize || 5000,
       };
     }));
   }

--- a/packages/table/src/toolbar/DownloadButtonView.js
+++ b/packages/table/src/toolbar/DownloadButtonView.js
@@ -110,7 +110,6 @@ const DownloadButton = ({
   async function downloadFile(type) {
     try {
       const { totalCount, pageSize } = await fetchCountWithRetry();
-      console.log(`FIND-ME: Downloading ${totalCount} entries...`);
 
       let completedEntries = 0;
       let allData = [];
@@ -125,7 +124,6 @@ const DownloadButton = ({
         // eslint-disable-next-line no-await-in-loop
         const data = await fetchDownloadWithRetry(variables);
         allData = allData.concat(data);
-        console.log(`FIND-ME: Downloaded ${allData.length} / ${totalCount} entries...`);
         completedEntries += data.length;
       }
       downloadData(cleanData(allData), table, table.downloadFileName, type);
@@ -134,13 +132,61 @@ const DownloadButton = ({
     }
   }
 
+  async function downloadFileParallel(type, concurrency = 5) {
+    try {
+      const { totalCount, pageSize } = await fetchCountWithRetry();
+      const totalChunks = Math.ceil(totalCount / pageSize);
+      const results = new Array(totalChunks);
+
+      for (let i = 0; i < totalChunks; i += concurrency) {
+        const batch = [];
+
+        for (let j = i; j < Math.min(i + concurrency, totalChunks); j += 1) {
+          const offset = j * pageSize;
+          const first = Math.min(pageSize, totalCount - offset);
+
+          const variables = {
+            ...queryVariables,
+            offset,
+            first,
+            order_by: table.sortBy,
+            sort_direction: table.sortOrder,
+          };
+
+          batch.push(
+            fetchDownloadWithRetry(variables).then((data) => ({ index: j, data })),
+          );
+        }
+
+        // eslint-disable-next-line no-await-in-loop
+        const batchResults = await Promise.all(batch);
+        batchResults.forEach(({ index, data }) => {
+          results[index] = data;
+        });
+      }
+
+      const allData = results.flat();
+      downloadData(cleanData(allData), table, table.downloadFileName, type);
+    } catch (error) {
+      console.error('Error fetching count:', error);
+    }
+  }
+
   const downloadTableCSV = useCallback(() => {
-    downloadFile('csv');
+    if (table.asyncDownload) {
+      downloadFileParallel('csv');
+    } else {
+      downloadFile('csv');
+    }
     setListDisplay('none');
   }, [queryVariables, table]);
 
   const downloadTableJson = useCallback(() => {
-    downloadFile('json');
+    if (table.asyncDownload) {
+      downloadFileParallel('json');
+    } else {
+      downloadFile('json');
+    }
     setListDisplay('none');
   }, [queryVariables, table]);
 

--- a/packages/table/src/toolbar/DownloadButtonView.js
+++ b/packages/table/src/toolbar/DownloadButtonView.js
@@ -70,7 +70,7 @@ const DownloadButton = ({
     return cleanedResult;
   }
 
-  async function downloadSCSVFile() {
+  async function downloadFile(type) {
     const {
       query,
       paginationAPIField,
@@ -92,42 +92,16 @@ const DownloadButton = ({
         }
         return response.data;
       });
-
-    downloadData(cleanData(result), table, table.downloadFileName, 'csv');
-  }
-
-  async function downloadJsonFile() {
-    const {
-      query,
-      paginationAPIField,
-    } = table;
-
-    const result = await client.query({
-      query,
-      variables: {
-        ...queryVariables,
-        page: 0,
-        first: downloadLimit,
-        order_by: table.sortBy,
-        sort_direction: table.sortOrder,
-      },
-    })
-      .then((response) => {
-        if (paginationAPIField && response && response.data) {
-          return response.data[paginationAPIField];
-        }
-        return response.data;
-      });
-    downloadData(cleanData(result), table, table.downloadFileName, 'json');
+    downloadData(cleanData(result), table, table.downloadFileName, type);
   }
 
   const downloadTableCSV = useCallback(() => {
-    downloadSCSVFile();
+    downloadFile('csv');
     setListDisplay('none');
   }, [queryVariables, table]);
 
   const downloadTableJson = useCallback(() => {
-    downloadJsonFile();
+    downloadFile('json');
     setListDisplay('none');
   }, [queryVariables, table]);
 

--- a/packages/table/src/toolbar/DownloadButtonView.js
+++ b/packages/table/src/toolbar/DownloadButtonView.js
@@ -90,7 +90,7 @@ const DownloadButton = ({
       const queryResponse = data[statsQueryName];
       return {
         totalCount: queryResponse[statsField],
-        pageSize: queryResponse.pageSize || downloadLimit,
+        pageSize: downloadLimit || queryResponse.pageSize,
       };
     }));
   }

--- a/packages/table/src/toolbar/DownloadButtonView.js
+++ b/packages/table/src/toolbar/DownloadButtonView.js
@@ -26,6 +26,7 @@ const DownloadButton = ({
   buttonConfig,
 }) => {
   const [listDisplay, setListDisplay] = useState('none');
+  const [isDownloading, setIsDownloading] = useState(false);
   const dropdownSelection = useRef(null);
   const useOutsideAlerter = (ref) => {
     useEffect(() => {
@@ -47,7 +48,7 @@ const DownloadButton = ({
   }
 
   const client = useApolloClient();
-  const downloadLimit = buttonConfig?.downloadLimit || 10000;
+  const downloadLimit = buttonConfig?.downloadLimit || 5000;
 
   function cleanData(result) {
     function hasHTMLTags(str) {
@@ -108,6 +109,7 @@ const DownloadButton = ({
   }
 
   async function downloadFile(type) {
+    setIsDownloading(true);
     try {
       const { totalCount, pageSize } = await fetchCountWithRetry();
 
@@ -129,10 +131,13 @@ const DownloadButton = ({
       downloadData(cleanData(allData), table, table.downloadFileName, type);
     } catch (error) {
       console.error('Error fetching count:', error);
+    } finally {
+      setIsDownloading(false);
     }
   }
 
   async function downloadFileParallel(type, concurrency = 5) {
+    setIsDownloading(true);
     try {
       const { totalCount, pageSize } = await fetchCountWithRetry();
       const totalChunks = Math.ceil(totalCount / pageSize);
@@ -169,28 +174,33 @@ const DownloadButton = ({
       downloadData(cleanData(allData), table, table.downloadFileName, type);
     } catch (error) {
       console.error('Error fetching count:', error);
+    } finally {
+      setIsDownloading(false);
     }
   }
 
   const downloadTableCSV = useCallback(() => {
+    if (isDownloading) return;
     if (table.asyncDownload) {
       downloadFileParallel('csv');
     } else {
       downloadFile('csv');
     }
     setListDisplay('none');
-  }, [queryVariables, table]);
+  }, [queryVariables, table, isDownloading]);
 
   const downloadTableJson = useCallback(() => {
+    if (isDownloading) return;
     if (table.asyncDownload) {
       downloadFileParallel('json');
     } else {
       downloadFile('json');
     }
     setListDisplay('none');
-  }, [queryVariables, table]);
+  }, [queryVariables, table, isDownloading]);
 
   const handleClickButton = () => {
+    if (isDownloading) return;
     if (listDisplay === 'none') {
       setListDisplay('block');
     } else {
@@ -246,11 +256,11 @@ const DownloadButton = ({
   const classes = useStyles();
 
   return (
-    <div className={classes.dropdown}>
+    <div className={classes.dropdown} style={isDownloading ? { cursor: 'wait' } : {}}>
 
-      <Tooltip title={table.downloadButtonTooltipText || 'Download filtered results'}>
+      <Tooltip title={isDownloading ? 'Download in progress...' : (table.downloadButtonTooltipText || 'Download filtered results')}>
         {
-          count !== 0
+          count !== 0 && !isDownloading
             ? (
               <IconButton onClick={handleClickButton} style={{ padding: '0' }}>
                 <CloudDownload />

--- a/packages/table/src/toolbar/DownloadButtonView.js
+++ b/packages/table/src/toolbar/DownloadButtonView.js
@@ -90,7 +90,7 @@ const DownloadButton = ({
       const queryResponse = data[statsQueryName];
       return {
         totalCount: queryResponse[statsField],
-        pageSize: downloadLimit || queryResponse.pageSize,
+        pageSize: downloadLimit ?? queryResponse.pageSize,
       };
     }));
   }
@@ -260,9 +260,9 @@ const DownloadButton = ({
 
       <Tooltip title={isDownloading ? 'Download in progress...' : (table.downloadButtonTooltipText || 'Download filtered results')}>
         {
-          count !== 0 && !isDownloading
+          count !== 0
             ? (
-              <IconButton onClick={handleClickButton} style={{ padding: '0' }}>
+              <IconButton onClick={handleClickButton} style={{ padding: '0' }} disabled={isDownloading}>
                 <CloudDownload />
                 <KeyboardArrowDownOutlinedIcon className={classes.arrowdownIcon} />
               </IconButton>

--- a/packages/table/src/toolbar/DownloadButtonView.js
+++ b/packages/table/src/toolbar/DownloadButtonView.js
@@ -70,29 +70,68 @@ const DownloadButton = ({
     return cleanedResult;
   }
 
-  async function downloadFile(type) {
-    const {
-      query,
-      paginationAPIField,
-    } = table;
+  // --- retry helper (recursive ESLINT no await-in-loop — we want this to be sequential) ---
+  async function retry(fn, retries = 3, attempt = 1) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (attempt >= retries) throw err;
+      return retry(fn, retries, attempt + 1);
+    }
+  }
 
-    const result = await client.query({
+  async function fetchCountWithRetry() {
+    const { statsQuery, statsQueryName, statsField } = table;
+    return retry(() => client.query({
+      query: statsQuery,
+      variables: queryVariables,
+    }).then(({ data }) => {
+      const queryResponse = data[statsQueryName];
+      return {
+        totalCount: queryResponse[statsField],
+        pageSize: queryResponse.pageSize || downloadLimit,
+      };
+    }));
+  }
+
+  async function fetchDownloadWithRetry(variables) {
+    const { query, paginationAPIField } = table;
+    return retry(() => client.query({
       query,
-      variables: {
-        ...queryVariables,
-        page: 0,
-        first: downloadLimit,
-        order_by: table.sortBy,
-        sort_direction: table.sortOrder,
-      },
-    })
-      .then((response) => {
-        if (paginationAPIField && response && response.data) {
-          return response.data[paginationAPIField];
-        }
-        return response.data;
-      });
-    downloadData(cleanData(result), table, table.downloadFileName, type);
+      variables,
+    }).then((response) => {
+      if (paginationAPIField && response && response.data) {
+        return response.data[paginationAPIField];
+      }
+      return response.data;
+    }));
+  }
+
+  async function downloadFile(type) {
+    try {
+      const { totalCount, pageSize } = await fetchCountWithRetry();
+      console.log(`FIND-ME: Downloading ${totalCount} entries...`);
+
+      let completedEntries = 0;
+      let allData = [];
+      while (completedEntries < totalCount) {
+        const variables = {
+          ...queryVariables,
+          offset: Math.floor(completedEntries / pageSize) * pageSize,
+          first: Math.min(pageSize, totalCount - completedEntries),
+          order_by: table.sortBy,
+          sort_direction: table.sortOrder,
+        };
+        // eslint-disable-next-line no-await-in-loop
+        const data = await fetchDownloadWithRetry(variables);
+        allData = allData.concat(data);
+        console.log(`FIND-ME: Downloaded ${allData.length} / ${totalCount} entries...`);
+        completedEntries += data.length;
+      }
+      downloadData(cleanData(allData), table, table.downloadFileName, type);
+    } catch (error) {
+      console.error('Error fetching count:', error);
+    }
   }
 
   const downloadTableCSV = useCallback(() => {

--- a/packages/table/src/toolbar/DownloadButtonView.js
+++ b/packages/table/src/toolbar/DownloadButtonView.js
@@ -23,6 +23,7 @@ const DownloadButton = ({
   count,
   queryVariables,
   table,
+  buttonConfig,
 }) => {
   const [listDisplay, setListDisplay] = useState('none');
   const dropdownSelection = useRef(null);
@@ -46,6 +47,7 @@ const DownloadButton = ({
   }
 
   const client = useApolloClient();
+  const downloadLimit = buttonConfig?.downloadLimit || 10000;
 
   function cleanData(result) {
     function hasHTMLTags(str) {
@@ -79,7 +81,7 @@ const DownloadButton = ({
       variables: {
         ...queryVariables,
         page: 0,
-        first: 10000,
+        first: downloadLimit,
         order_by: table.sortBy,
         sort_direction: table.sortOrder,
       },
@@ -105,7 +107,7 @@ const DownloadButton = ({
       variables: {
         ...queryVariables,
         page: 0,
-        first: 10000,
+        first: downloadLimit,
         order_by: table.sortBy,
         sort_direction: table.sortOrder,
       },


### PR DESCRIPTION
## Description

- Now enables the user to download more than 10k entries at once. We do this by separating out the chunks with a given page size and then send multiple queries and rejoin them together.
- Also added in optional async download
- Also added in download in progress state to show that download is in progress by disabling the button and changing the cursor to loading on hover

Fixes # (issue)
[C3DC-1888](https://tracker.nci.nih.gov/browse/C3DC-1888)
## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?
Locally