### PR TITLE
CTDC-1831: Show placeholder and message when DonutChart data is empty

### DIFF
--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bento-core/widgets",
-  "version": "1.0.1-ctdc.1",
+  "version": "1.0.1-ctdc.2",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/widgets/src/DonutChart/DonutChartGenerator.js
+++ b/packages/widgets/src/DonutChart/DonutChartGenerator.js
@@ -206,30 +206,71 @@ export const DonutChartGenerator = (uiConfig = DEFAULT_CONFIG_DONUT) => {
 
       return (
         <ResponsiveContainer width={width} height={height}>
-          <PieChart>
-            <Pie
-              data={dataset}
-              activeIndex={activeIndex}
-              blendStroke={blendStroke || true}
-              cx={cx || '50%'}
-              cy={cy || '50%'}
-              innerRadius={innerRadius}
-              outerRadius={outerRadius}
-              dataKey="value"
-              paddingAngle={cellPadding}
-              activeShape={(currentProps) => (mergeProps(currentProps, defaultProps, activeShape))}
-              onMouseEnter={(d, idx) => setActiveIndex(idx)}
-            >
-              {data.map((entry, index) => (
-                <Cell
-                  key={`cell-${index}`}
-                  fill={data.length % 2 === 0
-                    ? COLORS_EVEN[index % COLORS_EVEN.length]
-                    : COLORS_ODD[index % COLORS_ODD.length]}
-                />
-              ))}
-            </Pie>
-          </PieChart>
+          {data?.length === 0 ? (
+            <PieChart>
+              <Pie
+                data={[{ name: 'Empty', value: 1 }]}
+                cx={cx || '50%'}
+                cy={cy || '50%'}
+                innerRadius={innerRadius}
+                outerRadius={outerRadius}
+                dataKey="value"
+                startAngle={0}
+                endAngle={360}
+                activeShape={null}
+                onMouseEnter={() => {}}
+              >
+                <Cell fill="#E2E2E2" />
+              </Pie>
+              <text
+                x="50%"
+                y="50%"
+                textAnchor="middle"
+                fontSize="12px"
+                fontWeight="400"
+                fontFamily="Nunito"
+              >
+                <tspan x="50%" dy="-18">
+                  No data
+                </tspan>
+                <tspan x="50%" dy="18">
+                  returned for
+                </tspan>
+                <tspan x="50%" dy="18">
+                  this search
+                </tspan>
+              </text>
+            </PieChart>
+          ) : (
+            <PieChart>
+              <Pie
+                data={dataset}
+                activeIndex={activeIndex}
+                blendStroke={blendStroke || true}
+                cx={cx || '50%'}
+                cy={cy || '50%'}
+                innerRadius={innerRadius}
+                outerRadius={outerRadius}
+                dataKey="value"
+                paddingAngle={cellPadding}
+                activeShape={
+                  (currentProps) => mergeProps(currentProps, defaultProps, activeShape)
+                }
+                onMouseEnter={(d, idx) => setActiveIndex(idx)}
+              >
+                {data.map((entry, index) => (
+                  <Cell
+                    key={`cell-${index}`}
+                    fill={
+                      data.length % 2 === 0
+                        ? COLORS_EVEN[index % COLORS_EVEN.length]
+                        : COLORS_ODD[index % COLORS_ODD.length]
+                    }
+                  />
+                ))}
+              </Pie>
+            </PieChart>
+          )}
         </ResponsiveContainer>
       );
     },


### PR DESCRIPTION
## Description

Added conditional rendering to the DonutChart so that when the data array is empty, a placeholder pie and a "No data returned for this search" message are displayed. This improves user feedback in cases where no chart data is available.

The logic is adapted from: https://github.com/CBIIT/bento-frontend/pull/1139

Fixes # (issue) CTDC-1831

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manual testing on local