### PR TITLE
centralized slider clear logic to the reducers

### DIFF
--- a/packages/facet-filter/package.json
+++ b/packages/facet-filter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bento-core/facet-filter",
-  "version": "1.0.1-c3dc.9",
+  "version": "1.0.1-c3dc.10",
   "description": "### Bento core sidebar design:",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/facet-filter/src/components/facet/NewFacetView.js
+++ b/packages/facet-filter/src/components/facet/NewFacetView.js
@@ -27,7 +27,6 @@ const NewFacetView = ({
   facet,
   onClearFacetSection,
   onClearSliderSection,
-  onUnknownAgesChange,
   CustomView,
   queryParams,
   timeUnitState,
@@ -78,10 +77,6 @@ const NewFacetView = ({
     // navigate(`/explore${queryStr}`, { replace: true });
     setSortBy(null);
 
-    // Reset the corresponding unknownAges parameter in Redux state
-    if (queryParams.includes(unknownAgesField) && onUnknownAgesChange) {
-      onUnknownAgesChange(field, 'include');
-    }
     if (facet.type === InputTypes.SLIDER) {
       onClearSliderSection(facet);
     } else {

--- a/packages/facet-filter/src/store/reducers/SideBarReducer.js
+++ b/packages/facet-filter/src/store/reducers/SideBarReducer.js
@@ -42,13 +42,22 @@ export const onClearFacetSection = ({
 export const onClearSliderSection = ({
   filterState,
   facetSection,
+  unknownAgesState,
 }) => {
-  const updatedState = { ...filterState };
+  const updatedFilterState = { ...filterState };
+  const updatedUnknownAgesState = { ...unknownAgesState };
   const { datafield } = facetSection;
-  if (updatedState[datafield]) {
-    delete updatedState[datafield];
+
+  if (updatedFilterState[datafield]) {
+    delete updatedFilterState[datafield];
   }
-  return updatedState;
+
+  // Also clear the unknownAgesState for this datafield
+  if (updatedUnknownAgesState[datafield]) {
+    delete updatedUnknownAgesState[datafield];
+  }
+
+  return { filterState: updatedFilterState, unknownAgesState: updatedUnknownAgesState };
 };
 
 export const updateSiderValue = ({
@@ -125,6 +134,7 @@ export function sideBarReducerGenerator() {
             ...state,
             filterState: {},
             searchState: {},
+            unknownAgesState: {},
           };
         case sideBarActionTypes.CLEAR_FACET_SECTION:
           updateState = onClearFacetSection({ ...payload, ...state });
@@ -136,7 +146,8 @@ export function sideBarReducerGenerator() {
           updateState = onClearSliderSection({ ...payload, ...state });
           return {
             ...state,
-            filterState: { ...updateState },
+            filterState: { ...updateState.filterState },
+            unknownAgesState: { ...updateState.unknownAgesState },
           };
         case sideBarActionTypes.CLEAR_AND_SELECT_FACET_VALUE:
           return {

--- a/packages/query-bar/package.json
+++ b/packages/query-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bento-core/query-bar",
-  "version": "1.0.0-c3dc.9",
+  "version": "1.0.0-c3dc.10",
   "description": "This package provides the Query Bar component that displays the current Facet Search and Local Find filters on the Dashboard/Explore page. It also provides the direct ability to reset all or some of the filters with the click of a button. It is designed to be implemented directly with the:",
   "main": "dist/index.js",
   "scripts": {
@@ -23,7 +23,7 @@
     "react-redux": "^7.2.1"
   },
   "dependencies": {
-    "@bento-core/facet-filter": "^1.0.1-c3dc.9",
+    "@bento-core/facet-filter": "^1.0.1-c3dc.10",
     "lodash": "^4.17.20"
   },
   "author": "CTOS Bento Team",


### PR DESCRIPTION
## Description

There was an issue where the unknownAges state was not clearing properly. We have moved the logic from the FE to be in a centralized location within the store.

Fixes # (issue) [C3DC-1936](https://tracker.nci.nih.gov/browse/C3DC-1936)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Locally