### PR TITLE
C3DC-2045 added display filter on table download to download only shown columns

### DIFF
--- a/packages/paginated-table/package.json
+++ b/packages/paginated-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bento-core/paginated-table",
-  "version": "1.0.0-c3dc.39",
+  "version": "1.0.0-c3dc.40",
   "main": "dist/index.js",
   "scripts": {
     "build": "npm run lint && cross-env-shell rm -rf dist && NODE_ENV=production BABEL_ENV=es babel src --out-dir dist --copy-files",
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@bento-core/cart": "1.0.1-ccdihub.7",
-    "@bento-core/table": "^1.0.0-c3dc.33",
+    "@bento-core/table": "^1.0.0-c3dc.34",
     "@bento-core/tool-tip": "^1.0.0",
     "@bento-core/util": "^1.0.0"
   },

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bento-core/table",
-  "version": "1.0.0-c3dc.33",
+  "version": "1.0.0-c3dc.34",
   "main": "dist/index.js",
   "scripts": {
     "build": "cross-env-shell rm -rf dist && NODE_ENV=production BABEL_ENV=es babel src --out-dir dist --copy-files",

--- a/packages/table/src/util/downloadTable.js
+++ b/packages/table/src/util/downloadTable.js
@@ -63,8 +63,10 @@ export function convertToCSV(jsonse, keysToInclude, header) {
 
 export function downloadData(tableData, table, downloadFileName, format = 'csv') {
   const { columns = [] } = table;
-  const filterColumns = columns.filter(({ cellType, doNotDownload }) => (
-    !actionCellTypes.includes(cellType) && !doNotDownload));
+  const filterColumns = columns
+    .filter(({ cellType }) => !actionCellTypes.includes(cellType))
+    .filter(({ doNotDownload }) => !doNotDownload)
+    .filter(({ display }) => display);
   let formatDataVal = formatColumnValues(filterColumns, tableData);
 
   formatDataVal = formatDataVal.map((item) => {


### PR DESCRIPTION
## Description

C3DC wants to add a feature from CCDI Hub where, in conjunction with the column management, when the user downloads the table it will only download columns that are currently toggled on as opposed to downloading all the attributes. 

This is done by adding one filter clause to check if the display value is true.

Also formatted a little different so that each filter clause gets its own line

Fixes # (issue)
[C3DC-2045](https://tracker.nci.nih.gov/browse/C3DC-2045)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Locally