### PR TITLE
C3DC-2045 allowed for 'download only columns' to be downloaded even if hidden

### DIFF
--- a/packages/paginated-table/package.json
+++ b/packages/paginated-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bento-core/paginated-table",
-  "version": "1.0.0-c3dc.40",
+  "version": "1.0.0-c3dc.41",
   "main": "dist/index.js",
   "scripts": {
     "build": "npm run lint && cross-env-shell rm -rf dist && NODE_ENV=production BABEL_ENV=es babel src --out-dir dist --copy-files",
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@bento-core/cart": "1.0.1-ccdihub.7",
-    "@bento-core/table": "^1.0.0-c3dc.34",
+    "@bento-core/table": "^1.0.0-c3dc.35",
     "@bento-core/tool-tip": "^1.0.0",
     "@bento-core/util": "^1.0.0"
   },

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bento-core/table",
-  "version": "1.0.0-c3dc.34",
+  "version": "1.0.0-c3dc.35",
   "main": "dist/index.js",
   "scripts": {
     "build": "cross-env-shell rm -rf dist && NODE_ENV=production BABEL_ENV=es babel src --out-dir dist --copy-files",

--- a/packages/table/src/toolbar/ManageColumnView.js
+++ b/packages/table/src/toolbar/ManageColumnView.js
@@ -41,7 +41,7 @@ const ManageColumnView = ({
   const [needsScroll, setNeedsScroll] = useState(false);
 
   const viewColumns = columns.filter((col) => col.role === cellTypes.DISPLAY
-    && col.disableInManageView !== true);
+    && col.downloadOnly !== true);
 
   const dropdownSelection = useRef(null);
   const formGroupRef = useRef(null);

--- a/packages/table/src/util/downloadTable.js
+++ b/packages/table/src/util/downloadTable.js
@@ -66,7 +66,7 @@ export function downloadData(tableData, table, downloadFileName, format = 'csv')
   const filterColumns = columns
     .filter(({ cellType }) => !actionCellTypes.includes(cellType))
     .filter(({ doNotDownload }) => !doNotDownload)
-    .filter(({ display, disableInManageView }) => display || disableInManageView); // want to download hidden columns ('download only columns')
+    .filter(({ display, downloadOnly }) => display || downloadOnly); // want to download hidden columns ('download only columns')
   let formatDataVal = formatColumnValues(filterColumns, tableData);
 
   formatDataVal = formatDataVal.map((item) => {

--- a/packages/table/src/util/downloadTable.js
+++ b/packages/table/src/util/downloadTable.js
@@ -66,7 +66,7 @@ export function downloadData(tableData, table, downloadFileName, format = 'csv')
   const filterColumns = columns
     .filter(({ cellType }) => !actionCellTypes.includes(cellType))
     .filter(({ doNotDownload }) => !doNotDownload)
-    .filter(({ display }) => display);
+    .filter(({ display, disableInManageView }) => display || disableInManageView); // want to download hidden columns ('download only columns')
   let formatDataVal = formatColumnValues(filterColumns, tableData);
 
   formatDataVal = formatDataVal.map((item) => {


### PR DESCRIPTION
## Description

I've updated the naming convention to make it clearer - there are some columns that are meant to be download only and not seen (formerly marked by disableInManageView). 

We now filter them in the display filter with an OR clause.

We will update the FE to reflect the the new naming convention

Fixes # (issue)
[C3DC-2045](https://tracker.nci.nih.gov/browse/C3DC-2045)
## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Locally