### PR TITLE
C3DC-2058 added slider bottom border

### DIFF
--- a/packages/facet-filter/package.json
+++ b/packages/facet-filter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bento-core/facet-filter",
-  "version": "1.0.1-c3dc.10",
+  "version": "1.0.1-c3dc.11",
   "description": "### Bento core sidebar design:",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/facet-filter/src/components/inputs/slider/SliderView.js
+++ b/packages/facet-filter/src/components/inputs/slider/SliderView.js
@@ -122,6 +122,11 @@ const SliderView = ({
     getDisplayValue(lowerBoundValue),
     getDisplayValue(upperBoundValue),
   ]);
+
+  // Check if slider text will be shown (to determine if unknownAgesSection needs bottom border)
+  const isSliderTextShown = (sliderValue[0] > getDisplayValue(minLowerBound)
+    || sliderValue[1] < getDisplayValue(maxUpperBound));
+
   useEffect(() => {
     // Don't reset slider values if "Only" is selected - preserve current values
     if (unknownAges === 'only') {
@@ -256,7 +261,10 @@ const SliderView = ({
         </Box>
       </div>
       {/* Unknown Ages Section */}
-      <Box className={classes.unknownAgesSection}>
+      <Box className={clsx(classes.unknownAgesSection, {
+        [classes.unknownAgesSectionWithBottomBorder]: !isSliderTextShown,
+      })}
+      >
         <Typography className={classes.unknownAgesTitle}>
           UNKNOWN AGES:
         </Typography>
@@ -487,6 +495,7 @@ const styles = () => ({
       whiteSpace: 'nowrap',
       overflow: 'hidden',
       textOverflow: 'ellipsis',
+      borderBottom: '1px solid #CCCCCC',
     }),
   invalidSliderText: (props) => (props.facet.style && props.facet.style.invalidSliderText
     ? props.facet.style.invalidSliderText
@@ -503,6 +512,7 @@ const styles = () => ({
       whiteSpace: 'nowrap',
       overflow: 'hidden',
       textOverflow: 'ellipsis',
+      borderBottom: '1px solid #CCCCCC',
     }),
   sliderListItem: (props) => (props.facet.style && props.facet.style.sliderListItem
     ? props.facet.style.sliderListItem
@@ -531,6 +541,12 @@ const styles = () => ({
       paddingBottom: '0px',
       borderTop: '1px solid #CCCCCC',
     }),
+  unknownAgesSectionWithBottomBorder: (props) => (
+    props.facet.style && props.facet.style.unknownAgesSectionWithBottomBorder
+      ? props.facet.style.unknownAgesSectionWithBottomBorder
+      : {
+        borderBottom: '1px solid #CCCCCC',
+      }),
   unknownAgesTitle: (props) => (props.facet.style && props.facet.style.unknownAgesTitle
     ? props.facet.style.unknownAgesTitle
     : {

--- a/packages/query-bar/package.json
+++ b/packages/query-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bento-core/query-bar",
-  "version": "1.0.0-c3dc.10",
+  "version": "1.0.0-c3dc.11",
   "description": "This package provides the Query Bar component that displays the current Facet Search and Local Find filters on the Dashboard/Explore page. It also provides the direct ability to reset all or some of the filters with the click of a button. It is designed to be implemented directly with the:",
   "main": "dist/index.js",
   "scripts": {
@@ -23,7 +23,7 @@
     "react-redux": "^7.2.1"
   },
   "dependencies": {
-    "@bento-core/facet-filter": "^1.0.1-c3dc.10",
+    "@bento-core/facet-filter": "^1.0.1-c3dc.11",
     "lodash": "^4.17.20"
   },
   "author": "CTOS Bento Team",


### PR DESCRIPTION
## Description

Updated the slider facet to have a bottom border
There are two states: When the unknown ages section is at the bottom of the facet or when there is some text (appears when user modifies the ranges).

Added logic to check to see which state is active and activates border style for the correct one

Fixes # (issue)
[C3DC-2058](https://tracker.nci.nih.gov/browse/C3DC-2058)
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Locally