### PR TITLE
CDS-1414 Fix facet classname issue with spaces

### DIFF
--- a/packages/facet-filter/src/components/facet/FacetView.js
+++ b/packages/facet-filter/src/components/facet/FacetView.js
@@ -57,6 +57,7 @@ const FacetView = ({
   displayFacet.facetValues = selectedItems;
   const isActiveFacet = [...selectedItems].length > 0;
   const limitCheckBoxCount = facet?.showCheckboxCount || 5;
+  const section = facet?.section?.replace(/\s+/g, '_') || '';
   return (
     <>
       <Accordion
@@ -66,14 +67,14 @@ const FacetView = ({
         classes={{
           root: classes.expansionPanelsideBarItem,
         }}
-        id={facet.section}
+        id={section}
       >
         { CustomView ? (
           <CustomView
             facet={facet}
             facetClasses={
-            isActiveFacet ? `activeFacet${facet.section}`
-              : `inactiveFacet${facet.section}`
+            isActiveFacet ? `activeFacet${section}`
+              : `inactiveFacet${section}`
             }
           />
         ) : (


### PR DESCRIPTION
## Description

Introduced first facet section with spaces which caused issues with class names. Replaced sequential spaces with an underline.

Fixes # [CDS-1414](https://tracker.nci.nih.gov/browse/CDS-1414)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tested manually on GC local.