### PR TITLE
C3DC-2030

### DIFF
--- a/packages/local-find/package.json
+++ b/packages/local-find/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bento-core/local-find",
-  "version": "1.0.0-c3dc.5",
+  "version": "1.0.0-c3dc.6",
   "description": "The Local Find package provides components relating to the Dashboard/Explore case search feature. There are two primary components provided by this package:",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/local-find/src/SearchBox/SearchBoxGenerator.js
+++ b/packages/local-find/src/SearchBox/SearchBoxGenerator.js
@@ -159,9 +159,10 @@ export const SearchBoxGenerator = (uiConfig = DEFAULT_CONFIG) => {
        * Handles the deletion of a search item under SearchList
        *
        * @param {string} val
+       * @param {string} type
        */
-      const onDelete = (val) => {
-        const newValue = value.filter((v) => v.title !== val);
+      const onDelete = (val, type) => {
+        const newValue = value.filter((v) => !(v.title === val && v.type === type));
         onChangeWrapper(newValue, null, true);
       };
 

--- a/packages/local-find/src/SearchBox/components/SearchList.js
+++ b/packages/local-find/src/SearchBox/components/SearchList.js
@@ -21,9 +21,9 @@ const SearchList = (props) => {
     onDelete,
   } = props;
 
-  const deleteWrapper = (item) => {
+  const deleteWrapper = (item, fullvalue) => {
     if (onDelete) {
-      onDelete(item);
+      onDelete(item, fullvalue);
     }
   };
 
@@ -47,8 +47,15 @@ const SearchList = (props) => {
                 </span>
               ))}
             </div>
-            <div className={classes.deleteIcon} onClick={() => deleteWrapper(item.title)}>
-              <img src="https://raw.githubusercontent.com/CBIIT/datacommons-assets/main/bento/images/icons/svgs/LocalFindCaseDeleteIcon.svg" alt="close icon" className={classes.closeRoot} />
+            <div
+              className={classes.deleteIcon}
+              onClick={() => deleteWrapper(item.title, item.type)}
+            >
+              <img
+                src="https://raw.githubusercontent.com/CBIIT/datacommons-assets/main/bento/images/icons/svgs/LocalFindCaseDeleteIcon.svg"
+                alt="close icon"
+                className={classes.closeRoot}
+              />
             </div>
           </ListItem>
         </>

--- a/packages/local-find/src/SearchBox/components/SearchList.js
+++ b/packages/local-find/src/SearchBox/components/SearchList.js
@@ -21,9 +21,9 @@ const SearchList = (props) => {
     onDelete,
   } = props;
 
-  const deleteWrapper = (item, fullvalue) => {
+  const deleteWrapper = (item, type) => {
     if (onDelete) {
-      onDelete(item, fullvalue);
+      onDelete(item, type);
     }
   };
 

--- a/packages/query-bar/package.json
+++ b/packages/query-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bento-core/query-bar",
-  "version": "1.0.0-c3dc.11",
+  "version": "1.0.0-c3dc.12",
   "description": "This package provides the Query Bar component that displays the current Facet Search and Local Find filters on the Dashboard/Explore page. It also provides the direct ability to reset all or some of the filters with the click of a button. It is designed to be implemented directly with the:",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/query-bar/src/generators/QueryBarGenerator.js
+++ b/packages/query-bar/src/generators/QueryBarGenerator.js
@@ -161,7 +161,7 @@ export const QueryBarGenerator = (uiConfig = DEFAULT_CONFIG) => {
                         <React.Fragment key={`pid-${idx}`}>
                           <span
                             className={clsx(classes.filterCheckboxes, classes.facetSectionCases)}
-                            onClick={() => deleteAutocompleteItem(d.title)}
+                            onClick={() => deleteAutocompleteItem(d)}
                           >
                             {d.title}
                           </span>
@@ -206,7 +206,7 @@ export const QueryBarGenerator = (uiConfig = DEFAULT_CONFIG) => {
                           className={
                             clsx(classes.filterCheckboxes, classes.localFindAssociatedIdsText)
                           }
-                          onClick={() => deleteAutocompleteItem(d.title)}
+                          onClick={() => deleteAutocompleteItem(d)}
                         >
                           {d.synonym}
                         </span>

--- a/packages/query-bar/src/generators/config.js
+++ b/packages/query-bar/src/generators/config.js
@@ -51,10 +51,10 @@ export default {
     /**
      * Delete a specific Local Find searchbox filter (case)
      *
-     * @param {string} title
+     * @param {object} item
      * @returns {void}
      */
-    deleteAutocompleteItem: (title) => {},
+    deleteAutocompleteItem: (item) => {},
 
     /**
      * Reset a specific facet section (e.g. Program)


### PR DESCRIPTION
Fix local find item removal to use both title and type for filtering

Summary
Updated the local find search functionality to properly identify and remove items by checking both title and type properties instead of just title. This ensures accurate item removal, particularly when dealing with items that might have similar titles but different types (e.g., synonyms vs. main items).

