### PR TITLE
C3DC-2000 Design QA Explore page; made components have configurable styles from FE

### DIFF
--- a/packages/about/package.json
+++ b/packages/about/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bento-core/about",
-  "version": "1.0.1-c3dc.0",
+  "version": "1.0.1-c3dc.1",
   "description": "",
   "main": "dist/index.js",
   "scripts": {
@@ -13,7 +13,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@bento-core/facet-filter": "^1.0.1-c3dc.3",
+    "@bento-core/facet-filter": "^1.0.1-c3dc.13",
     "lodash": "^4.17.20",
     "react-zoom-pan-pinch": "*"
   },

--- a/packages/facet-filter/package.json
+++ b/packages/facet-filter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bento-core/facet-filter",
-  "version": "1.0.1-c3dc.12",
+  "version": "1.0.1-c3dc.13",
   "description": "### Bento core sidebar design:",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/facet-filter/src/components/facet/ModalStyle.js
+++ b/packages/facet-filter/src/components/facet/ModalStyle.js
@@ -1,6 +1,6 @@
 import SearchIcon from './assets/Search_Icon.svg';
 
-export default () => ({
+const defaultStyles = {
   header: {
     display: 'flex',
     justifyContent: 'center',
@@ -112,9 +112,122 @@ export default () => ({
     fontSize: '10px',
     marginRight: '19px',
     marginLeft: 'auto',
-    // marginTop: '5px',
-    // float: 'right',
   },
   itemContainer: {
   },
+};
+
+export default () => ({
+  header: (props) => ({
+    ...defaultStyles.header,
+    ...(props.facet && props.facet.style && props.facet.style.modal
+      && props.facet.style.modal.header
+      ? props.facet.style.modal.header
+      : {}),
+  }),
+  closeButton: (props) => ({
+    ...defaultStyles.closeButton,
+    ...(props.facet && props.facet.style && props.facet.style.modal
+      && props.facet.style.modal.closeButton
+      ? props.facet.style.modal.closeButton
+      : {}),
+  }),
+  resetIcon: (props) => ({
+    ...defaultStyles.resetIcon,
+    ...(props.facet && props.facet.style && props.facet.style.modal
+      && props.facet.style.modal.resetIcon
+      ? props.facet.style.modal.resetIcon
+      : {}),
+  }),
+  modalTitle: (props) => ({
+    ...defaultStyles.modalTitle,
+    ...(props.facet && props.facet.style && props.facet.style.modal
+      && props.facet.style.modal.modalTitle
+      ? props.facet.style.modal.modalTitle
+      : {}),
+  }),
+  modalBody: (props) => ({
+    ...defaultStyles.modalBody,
+    ...(props.facet && props.facet.style && props.facet.style.modal
+      && props.facet.style.modal.modalBody
+      ? props.facet.style.modal.modalBody
+      : {}),
+  }),
+  searchContainer: (props) => ({
+    ...defaultStyles.searchContainer,
+    ...(props.facet && props.facet.style && props.facet.style.modal
+      && props.facet.style.modal.searchContainer
+      ? props.facet.style.modal.searchContainer
+      : {}),
+  }),
+  searchInputbox: (props) => ({
+    ...defaultStyles.searchInputbox,
+    ...(props.facet && props.facet.style && props.facet.style.modal
+      && props.facet.style.modal.searchInputbox
+      ? props.facet.style.modal.searchInputbox
+      : {}),
+  }),
+  searchBox: (props) => ({
+    ...defaultStyles.searchBox,
+    ...(props.facet && props.facet.style && props.facet.style.modal
+      && props.facet.style.modal.searchBox
+      ? props.facet.style.modal.searchBox
+      : {}),
+  }),
+  highlight: (props) => ({
+    ...defaultStyles.highlight,
+    ...(props.facet && props.facet.style && props.facet.style.modal
+      && props.facet.style.modal.highlight
+      ? props.facet.style.modal.highlight
+      : {}),
+  }),
+  sortGroup: (props) => ({
+    ...defaultStyles.sortGroup,
+    ...(props.facet && props.facet.style && props.facet.style.modal
+      && props.facet.style.modal.sortGroup
+      ? props.facet.style.modal.sortGroup
+      : {}),
+  }),
+  sortGroupIcon: (props) => ({
+    ...defaultStyles.sortGroupIcon,
+    ...(props.facet && props.facet.style && props.facet.style.modal
+      && props.facet.style.modal.sortGroupIcon
+      ? props.facet.style.modal.sortGroupIcon
+      : {}),
+  }),
+  sortGroupItem: (props) => ({
+    ...defaultStyles.sortGroupItem,
+    ...(props.facet && props.facet.style && props.facet.style.modal
+      && props.facet.style.modal.sortGroupItem
+      ? props.facet.style.modal.sortGroupItem
+      : {}),
+  }),
+  NonSortGroup: (props) => ({
+    ...defaultStyles.NonSortGroup,
+    ...(props.facet && props.facet.style && props.facet.style.modal
+      && props.facet.style.modal.NonSortGroup
+      ? props.facet.style.modal.NonSortGroup
+      : {}),
+  }),
+  NonSortGroupItem: (props) => ({
+    ...defaultStyles.NonSortGroupItem,
+    ...(props.facet && props.facet.style && props.facet.style.modal
+      && props.facet.style.modal.NonSortGroupItem
+      ? props.facet.style.modal.NonSortGroupItem
+      : {}),
+  }),
+  sortGroupItemCounts: (props) => ({
+    ...defaultStyles.sortGroupItemCounts,
+    ...(props.facet && props.facet.style && props.facet.style.modal
+      && props.facet.style.modal.sortGroupItemCounts
+      ? props.facet.style.modal.sortGroupItemCounts
+      : {}),
+  }),
+  itemContainer: (props) => ({
+    ...defaultStyles.itemContainer,
+    ...(props.facet && props.facet.style && props.facet.style.modal
+      && props.facet.style.modal.itemContainer
+      ? props.facet.style.modal.itemContainer
+      : {}),
+  }),
 });

--- a/packages/facet-filter/src/components/inputs/ModalFilterStyle.js
+++ b/packages/facet-filter/src/components/inputs/ModalFilterStyle.js
@@ -1,4 +1,4 @@
-export default () => ({
+const defaultStyles = {
   sortGroup: {
     paddingTop: '10px',
     marginBottom: '5px',
@@ -110,4 +110,91 @@ export default () => ({
     borderRight: '0.5px solid #000000',
     borderBottom: '0.5px solid #000000',
   },
+};
+
+export default () => ({
+  sortGroup: (props) => ({
+    ...defaultStyles.sortGroup,
+    ...(props.facet && props.facet.style && props.facet.style.modalFilter
+      && props.facet.style.modalFilter.sortGroup
+      ? props.facet.style.modalFilter.sortGroup
+      : {}),
+  }),
+  highlight: (props) => ({
+    ...defaultStyles.highlight,
+    ...(props.facet && props.facet.style && props.facet.style.modalFilter
+      && props.facet.style.modalFilter.highlight
+      ? props.facet.style.modalFilter.highlight
+      : {}),
+  }),
+  sortGroupIcon: (props) => ({
+    ...defaultStyles.sortGroupIcon,
+    ...(props.facet && props.facet.style && props.facet.style.modalFilter
+      && props.facet.style.modalFilter.sortGroupIcon
+      ? props.facet.style.modalFilter.sortGroupIcon
+      : {}),
+  }),
+  sortGroupItem: (props) => ({
+    ...defaultStyles.sortGroupItem,
+    ...(props.facet && props.facet.style && props.facet.style.modalFilter
+      && props.facet.style.modalFilter.sortGroupItem
+      ? props.facet.style.modalFilter.sortGroupItem
+      : {}),
+  }),
+  sortGroupItemCounts: (props) => ({
+    ...defaultStyles.sortGroupItemCounts,
+    ...(props.facet && props.facet.style && props.facet.style.modalFilter
+      && props.facet.style.modalFilter.sortGroupItemCounts
+      ? props.facet.style.modalFilter.sortGroupItemCounts
+      : {}),
+  }),
+  checkboxContainer: (props) => ({
+    ...defaultStyles.checkboxContainer,
+    ...(props.facet && props.facet.style && props.facet.style.modalFilter
+      && props.facet.style.modalFilter.checkboxContainer
+      ? props.facet.style.modalFilter.checkboxContainer
+      : {}),
+  }),
+  checkedContainer: (props) => ({
+    ...defaultStyles.checkedContainer,
+    ...(props.facet && props.facet.style && props.facet.style.modalFilter
+      && props.facet.style.modalFilter.checkedContainer
+      ? props.facet.style.modalFilter.checkedContainer
+      : {}),
+  }),
+  itemsContainer: (props) => ({
+    ...defaultStyles.itemsContainer,
+    ...(props.facet && props.facet.style && props.facet.style.modalFilter
+      && props.facet.style.modalFilter.itemsContainer
+      ? props.facet.style.modalFilter.itemsContainer
+      : {}),
+  }),
+  sortingContainer: (props) => ({
+    ...defaultStyles.sortingContainer,
+    ...(props.facet && props.facet.style && props.facet.style.modalFilter
+      && props.facet.style.modalFilter.sortingContainer
+      ? props.facet.style.modalFilter.sortingContainer
+      : {}),
+  }),
+  selectionText: (props) => ({
+    ...defaultStyles.selectionText,
+    ...(props.facet && props.facet.style && props.facet.style.modalFilter
+      && props.facet.style.modalFilter.selectionText
+      ? props.facet.style.modalFilter.selectionText
+      : {}),
+  }),
+  totalText: (props) => ({
+    ...defaultStyles.totalText,
+    ...(props.facet && props.facet.style && props.facet.style.modalFilter
+      && props.facet.style.modalFilter.totalText
+      ? props.facet.style.modalFilter.totalText
+      : {}),
+  }),
+  emptyItem: (props) => ({
+    ...defaultStyles.emptyItem,
+    ...(props.facet && props.facet.style && props.facet.style.modalFilter
+      && props.facet.style.modalFilter.emptyItem
+      ? props.facet.style.modalFilter.emptyItem
+      : {}),
+  }),
 });

--- a/packages/facet-filter/src/components/inputs/checkbox/BaseCheckboxView.js
+++ b/packages/facet-filter/src/components/inputs/checkbox/BaseCheckboxView.js
@@ -171,7 +171,7 @@ const BaseCheckBoxView = ({
             [`${checkedSection}SubjectChecked`]: isChecked,
           })}
         >
-          {`(${subjects})`}
+          {`${subjects}`}
         </Typography>
       </ListItem>
       {showDivider && (

--- a/packages/facet-filter/src/components/inputs/checkbox/BaseCheckboxView.js
+++ b/packages/facet-filter/src/components/inputs/checkbox/BaseCheckboxView.js
@@ -166,7 +166,7 @@ const BaseCheckBoxView = ({
         )}
         <ListItemText />
         <Typography
-          className={clsx(`${checkedSection}Subjects`, {
+          className={clsx(classes.subjectsText, `${checkedSection}Subjects`, {
             [`${checkedSection}SubjectUnChecked`]: !isChecked,
             [`${checkedSection}SubjectChecked`]: isChecked,
           })}

--- a/packages/facet-filter/src/components/inputs/checkbox/BaseCheckboxView.js
+++ b/packages/facet-filter/src/components/inputs/checkbox/BaseCheckboxView.js
@@ -171,7 +171,7 @@ const BaseCheckBoxView = ({
             [`${checkedSection}SubjectChecked`]: isChecked,
           })}
         >
-          {`${subjects}`}
+          {`${Number(subjects).toLocaleString()}`}
         </Typography>
       </ListItem>
       {showDivider && (

--- a/packages/facet-filter/src/components/inputs/checkbox/CheckboxView.js
+++ b/packages/facet-filter/src/components/inputs/checkbox/CheckboxView.js
@@ -1,10 +1,59 @@
 import React from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import BaseCheckBoxView from './BaseCheckboxView';
-import styles from './CheckboxStyle';
+import defaultStyles from './CheckboxStyle';
 
 const CheckBoxView = (props) => (
   <BaseCheckBoxView {...props} showDivider />
 );
+
+const styles = () => {
+  const defaults = defaultStyles();
+
+  return {
+    listItemGutters: (props) => ({
+      ...defaults.listItemGutters,
+      ...(props.facet && props.facet.style && props.facet.style.checkbox
+        && props.facet.style.checkbox.listItemGutters
+        ? props.facet.style.checkbox.listItemGutters
+        : {}),
+    }),
+    checkboxRoot: (props) => ({
+      ...defaults.checkboxRoot,
+      ...(props.facet && props.facet.style && props.facet.style.checkbox
+        && props.facet.style.checkbox.checkboxRoot
+        ? props.facet.style.checkbox.checkboxRoot
+        : {}),
+    }),
+    panelDetailText: (props) => ({
+      ...defaults.panelDetailText,
+      ...(props.facet && props.facet.style && props.facet.style.checkbox
+        && props.facet.style.checkbox.panelDetailText
+        ? props.facet.style.checkbox.panelDetailText
+        : {}),
+    }),
+    panelSubjectText: (props) => ({
+      ...defaults.panelSubjectText,
+      ...(props.facet && props.facet.style && props.facet.style.checkbox
+        && props.facet.style.checkbox.panelSubjectText
+        ? props.facet.style.checkbox.panelSubjectText
+        : {}),
+    }),
+    checkboxLabel: (props) => ({
+      ...defaults.checkboxLabel,
+      ...(props.facet && props.facet.style && props.facet.style.checkbox
+        && props.facet.style.checkbox.checkboxLabel
+        ? props.facet.style.checkbox.checkboxLabel
+        : {}),
+    }),
+    checkboxName: (props) => ({
+      ...defaults.checkboxName,
+      ...(props.facet && props.facet.style && props.facet.style.checkbox
+        && props.facet.style.checkbox.checkboxName
+        ? props.facet.style.checkbox.checkboxName
+        : {}),
+    }),
+  };
+};
 
 export default withStyles(styles)(CheckBoxView);

--- a/packages/facet-filter/src/components/inputs/checkbox/ModalCheckboxStyle.js
+++ b/packages/facet-filter/src/components/inputs/checkbox/ModalCheckboxStyle.js
@@ -1,4 +1,4 @@
-export default () => ({
+const defaultStyles = {
   listItemGutters: {
     padding: '10px 10px 10px 0px',
     width: '33.33%',
@@ -33,4 +33,49 @@ export default () => ({
     fontFamily: 'Nunito',
     lineHeight: '120%',
   },
+};
+
+export default () => ({
+  listItemGutters: (props) => ({
+    ...defaultStyles.listItemGutters,
+    ...(props.facet && props.facet.style && props.facet.style.modalCheckbox
+      && props.facet.style.modalCheckbox.listItemGutters
+      ? props.facet.style.modalCheckbox.listItemGutters
+      : {}),
+  }),
+  checkboxRoot: (props) => ({
+    ...defaultStyles.checkboxRoot,
+    ...(props.facet && props.facet.style && props.facet.style.modalCheckbox
+      && props.facet.style.modalCheckbox.checkboxRoot
+      ? props.facet.style.modalCheckbox.checkboxRoot
+      : {}),
+  }),
+  panelDetailText: (props) => ({
+    ...defaultStyles.panelDetailText,
+    ...(props.facet && props.facet.style && props.facet.style.modalCheckbox
+      && props.facet.style.modalCheckbox.panelDetailText
+      ? props.facet.style.modalCheckbox.panelDetailText
+      : {}),
+  }),
+  panelSubjectText: (props) => ({
+    ...defaultStyles.panelSubjectText,
+    ...(props.facet && props.facet.style && props.facet.style.modalCheckbox
+      && props.facet.style.modalCheckbox.panelSubjectText
+      ? props.facet.style.modalCheckbox.panelSubjectText
+      : {}),
+  }),
+  checkboxLabel: (props) => ({
+    ...defaultStyles.checkboxLabel,
+    ...(props.facet && props.facet.style && props.facet.style.modalCheckbox
+      && props.facet.style.modalCheckbox.checkboxLabel
+      ? props.facet.style.modalCheckbox.checkboxLabel
+      : {}),
+  }),
+  checkboxName: (props) => ({
+    ...defaultStyles.checkboxName,
+    ...(props.facet && props.facet.style && props.facet.style.modalCheckbox
+      && props.facet.style.modalCheckbox.checkboxName
+      ? props.facet.style.modalCheckbox.checkboxName
+      : {}),
+  }),
 });

--- a/packages/facet-filter/src/components/inputs/checkbox/ModalCheckboxStyle.js
+++ b/packages/facet-filter/src/components/inputs/checkbox/ModalCheckboxStyle.js
@@ -33,6 +33,7 @@ const defaultStyles = {
     fontFamily: 'Nunito',
     lineHeight: '120%',
   },
+  subjectsText: {},
 };
 
 export default () => ({
@@ -76,6 +77,13 @@ export default () => ({
     ...(props.facet && props.facet.style && props.facet.style.modalCheckbox
       && props.facet.style.modalCheckbox.checkboxName
       ? props.facet.style.modalCheckbox.checkboxName
+      : {}),
+  }),
+  subjectsText: (props) => ({
+    ...defaultStyles.subjectsText,
+    ...(props.facet && props.facet.style && props.facet.style.modalCheckbox
+      && props.facet.style.modalCheckbox.subjectsText
+      ? props.facet.style.modalCheckbox.subjectsText
       : {}),
   }),
 });

--- a/packages/facet-filter/src/components/inputs/checkbox/SearchCheckboxView.js
+++ b/packages/facet-filter/src/components/inputs/checkbox/SearchCheckboxView.js
@@ -1,10 +1,59 @@
 import React from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import BaseCheckBoxView from './BaseCheckboxView';
-import styles from './CheckboxStyle';
+import defaultStyles from './CheckboxStyle';
 
 const CheckBoxView = (props) => (
   <BaseCheckBoxView {...props} showDivider />
 );
+
+const styles = () => {
+  const defaults = defaultStyles();
+
+  return {
+    listItemGutters: (props) => ({
+      ...defaults.listItemGutters,
+      ...(props.facet && props.facet.style && props.facet.style.checkbox
+        && props.facet.style.checkbox.listItemGutters
+        ? props.facet.style.checkbox.listItemGutters
+        : {}),
+    }),
+    checkboxRoot: (props) => ({
+      ...defaults.checkboxRoot,
+      ...(props.facet && props.facet.style && props.facet.style.checkbox
+        && props.facet.style.checkbox.checkboxRoot
+        ? props.facet.style.checkbox.checkboxRoot
+        : {}),
+    }),
+    panelDetailText: (props) => ({
+      ...defaults.panelDetailText,
+      ...(props.facet && props.facet.style && props.facet.style.checkbox
+        && props.facet.style.checkbox.panelDetailText
+        ? props.facet.style.checkbox.panelDetailText
+        : {}),
+    }),
+    panelSubjectText: (props) => ({
+      ...defaults.panelSubjectText,
+      ...(props.facet && props.facet.style && props.facet.style.checkbox
+        && props.facet.style.checkbox.panelSubjectText
+        ? props.facet.style.checkbox.panelSubjectText
+        : {}),
+    }),
+    checkboxLabel: (props) => ({
+      ...defaults.checkboxLabel,
+      ...(props.facet && props.facet.style && props.facet.style.checkbox
+        && props.facet.style.checkbox.checkboxLabel
+        ? props.facet.style.checkbox.checkboxLabel
+        : {}),
+    }),
+    checkboxName: (props) => ({
+      ...defaults.checkboxName,
+      ...(props.facet && props.facet.style && props.facet.style.checkbox
+        && props.facet.style.checkbox.checkboxName
+        ? props.facet.style.checkbox.checkboxName
+        : {}),
+    }),
+  };
+};
 
 export default withStyles(styles)(CheckBoxView);

--- a/packages/facet-filter/src/components/inputs/slider/InputMinMaxView.js
+++ b/packages/facet-filter/src/components/inputs/slider/InputMinMaxView.js
@@ -3,7 +3,7 @@ import {
   Input,
 } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
-import styles from './InputMinMaxStyle';
+import defaultStyles from './InputMinMaxStyle';
 import { silderTypes } from '../Types';
 
 function InputMinMaxView({
@@ -45,5 +45,24 @@ function InputMinMaxView({
     />
   );
 }
+
+const styles = () => {
+  const defaults = defaultStyles();
+
+  return {
+    slider_INPUT_MIN: (props) => ({
+      ...defaults.slider_INPUT_MIN,
+      ...(props.customStyles && props.customStyles.slider_INPUT_MIN
+        ? props.customStyles.slider_INPUT_MIN
+        : {}),
+    }),
+    slider_INPUT_MAX: (props) => ({
+      ...defaults.slider_INPUT_MAX,
+      ...(props.customStyles && props.customStyles.slider_INPUT_MAX
+        ? props.customStyles.slider_INPUT_MAX
+        : {}),
+    }),
+  };
+};
 
 export default withStyles(styles)(InputMinMaxView);

--- a/packages/facet-filter/src/components/inputs/slider/SliderView.js
+++ b/packages/facet-filter/src/components/inputs/slider/SliderView.js
@@ -559,13 +559,17 @@ const styles = () => ({
       marginBottom: '6px',
       letterSpacing: '0.25px',
     }),
-  unknownAgesFormControl: {
-    width: '100%',
-  },
-  unknownAgesRadioGroup: {
-    flexDirection: 'row',
-    gap: '10px',
-  },
+  unknownAgesFormControl: (props) => (props.facet.style && props.facet.style.unknownAgesFormControl
+    ? props.facet.style.unknownAgesFormControl
+    : {
+      width: '100%',
+    }),
+  unknownAgesRadioGroup: (props) => (props.facet.style && props.facet.style.unknownAgesRadioGroup
+    ? props.facet.style.unknownAgesRadioGroup
+    : {
+      flexDirection: 'row',
+      gap: '10px',
+    }),
   radioLabel: (props) => (props.facet.style && props.facet.style.radioLabel
     ? props.facet.style.radioLabel
     : {

--- a/packages/facet-filter/src/components/inputs/slider/SliderView.js
+++ b/packages/facet-filter/src/components/inputs/slider/SliderView.js
@@ -200,6 +200,7 @@ const SliderView = ({
               onInputChange={handleChangeCommittedSlider}
               disabled={isBoundsInvalid || isOnlyUnknownAges}
               step={timeUnit === 'years' ? 0.01 : 1}
+              customStyles={facet.style && facet.style.inputMinMax}
             />
           </div>
           <div className={classes.maxValue}>
@@ -216,6 +217,7 @@ const SliderView = ({
               onInputChange={handleChangeCommittedSlider}
               disabled={isBoundsInvalid || isOnlyUnknownAges}
               step={timeUnit === 'years' ? 0.01 : 1}
+              customStyles={facet.style && facet.style.inputMinMax}
             />
           </div>
         </div>

--- a/packages/query-bar/package.json
+++ b/packages/query-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bento-core/query-bar",
-  "version": "1.0.0-c3dc.13",
+  "version": "1.0.0-c3dc.14",
   "description": "This package provides the Query Bar component that displays the current Facet Search and Local Find filters on the Dashboard/Explore page. It also provides the direct ability to reset all or some of the filters with the click of a button. It is designed to be implemented directly with the:",
   "main": "dist/index.js",
   "scripts": {
@@ -23,7 +23,7 @@
     "react-redux": "^7.2.1"
   },
   "dependencies": {
-    "@bento-core/facet-filter": "^1.0.1-c3dc.12",
+    "@bento-core/facet-filter": "^1.0.1-c3dc.13",
     "lodash": "^4.17.20"
   },
   "author": "CTOS Bento Team",


### PR DESCRIPTION
## Description

Design QA required updated styling of components 
- updated most of the relevant components to accept stylings from the FE and overwrite default stylings
- updated checkboxes to no longer have parentheses
- updated checkboxes to now format numbers with a comma (1000 -> 1,000)


Fixes # (issue)
[C3DC-2000](https://tracker.nci.nih.gov/browse/C3DC-2000)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Locally