### PR TITLE
* Design qa updates

### DIFF
--- a/packages/KMPlot/package.json
+++ b/packages/KMPlot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bento-core/kmplot",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/KMPlot/src/kmplot.js
+++ b/packages/KMPlot/src/kmplot.js
@@ -165,7 +165,7 @@ export default function KaplanMeierChart({
             return (
               <g key={`xt${i}`}>
                 <line x1={x(t)} y1={margin + innerH} x2={x(t)} y2={margin + innerH + 6} stroke="#333" />
-                <text x={x(t)} y={margin + innerH + 18} textAnchor="middle" fontSize={12}>{Math.round(t)}</text>
+                <text x={x(t)} y={margin + innerH + 18} textAnchor="middle" fontSize={11}>{Math.round(t)}</text>
               </g>
             );
           })}
@@ -177,7 +177,7 @@ export default function KaplanMeierChart({
             return (
               <g key={`yt${i}`}>
                 <line x1={margin - 6} y1={y(s)} x2={margin} y2={y(s)} stroke="#333" />
-                <text x={margin - 10} y={y(s) + 4} textAnchor="end" fontSize={12}>{s.toFixed(1)}</text>
+                <text x={margin - 10} y={y(s) + 4} textAnchor="end" fontSize={11}>{s.toFixed(1)}</text>
                 <line x1={margin + xAxisOffset} y1={y(s)} x2={margin + innerW + xAxisOffset} y2={y(s)} stroke="#ddd" />
               </g>
             );

--- a/packages/risk-table/package.json
+++ b/packages/risk-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bento-core/risk-table",
-  "version": "1.0.0-c3dc.5",
+  "version": "1.0.0-c3dc.6",
   "description": "The Risk Table component displays survival data for multiple cohorts over time intervals with colored indicators.",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/risk-table/src/RiskTableView.js
+++ b/packages/risk-table/src/RiskTableView.js
@@ -171,7 +171,7 @@ const styles = () => ({
   },
   firstHeaderCell: {
     textAlign: 'left',
-    fontSize: '10px',
+    fontSize: '11px',
     fontWeight: 600,
     color: '#333333',
     border: 'none',
@@ -189,7 +189,7 @@ const styles = () => ({
   secondHeaderCell: {
     position: 'relative',
     textAlign: 'center',
-    fontSize: '10px',
+    fontSize: '11px',
     fontWeight: 700,
     color: '#3A7587',
     border: '1px solid #666666',
@@ -206,7 +206,7 @@ const styles = () => ({
   },
   headerCell: {
     textAlign: 'center',
-    fontSize: '10px',
+    fontSize: '11px',
     fontWeight: 700,
     color: '#3A7587',
     border: '1px solid #666666',


### PR DESCRIPTION
Design QA Updates - Font Size Adjustments
This PR addresses design QA feedback by standardizing font sizes across the KMPlot and Risk Table components.
Changes
KMPlot Component (@bento-core/kmplot v0.1.2 → v0.1.3):
Reduced x-axis and y-axis label font size from 12px to 11px for consistency
Risk Table Component (@bento-core/risk-table v1.0.0-c3dc.5 → v1.0.0-c3dc.6):
Increased header cell font size from 10px to 11px for better readability
Applied to firstHeaderCell, secondHeaderCell, and headerCell styles
Impact
Improved visual consistency across components
Better readability for Risk Table headers
Package versions updated accordingly
