### PR TITLE
CDS-1526 Fix CSV export to properly escape array values and double quotes

### DIFF
--- a/packages/cart/src/utils.js
+++ b/packages/cart/src/utils.js
@@ -24,7 +24,8 @@ export function convertToCSV(jsonse, comments, keysToInclude, header) {
     keysToInclude.map((keyName) => {
       if (line !== '') line += ',';
       let columnResult = entry[keyName];
-      if (typeof columnResult === 'string') columnResult.replace(/"/g, '""');
+      if (Array.isArray(columnResult)) columnResult = columnResult.join(', ');
+      if (typeof columnResult === 'string') columnResult = columnResult.replace(/"/g, '""');
       if (typeof columnResult === 'string' && columnResult.search(/("|,|\n)/g) >= 0) columnResult = `"${columnResult}"`;
       line += columnResult !== null ? columnResult : ' ';
       return line;


### PR DESCRIPTION
## Description

Within the CSV export, the array values were not being handled properly and each entry would show up in a new column due to not properly escaping the values.

Fixes # [CDS-1526](https://tracker.nci.nih.gov/browse/CDS-1526)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tested manually on GC local.